### PR TITLE
Scutils log callbacks

### DIFF
--- a/docs/topics/utils/logfactory.rst
+++ b/docs/topics/utils/logfactory.rst
@@ -17,6 +17,8 @@ This single log instance allows you to:
 
     - Not worry about multi threaded applications creating too many loggers resulting in duplicated data
 
+    - Register callbacks to provide additional functionality when certain logging levels or criteria are met
+
 It is designed to be easy to use throughout your application, giving you a standard and flexible way to write your log data.
 
 .. method:: LogFactory.get_instance(json=False, stdout=True, name='scrapy-cluster',dir='logs', file='main.log', bytes=25000000, backups=5, level='INFO', format='%(asctime)s [%(name)s] %(levelname)s: %(message)s', propagate=False, include_extra=False)
@@ -33,7 +35,6 @@ It is designed to be easy to use throughout your application, giving you a stand
     :param propagate: Allow the log to propagate to other ancestor loggers
     :param include_extra: When not logging json, include the 'extra' param in the output
     :return: The log instance to use
-
 
 Usage
 -----
@@ -127,6 +128,49 @@ Scrapy Cluster's many components use arguments from the command line to set comm
 
     - Whether to write to a file or not
 
+If you would like to register a callback for extra functionality, you can use the following function on your logger object.
+
+.. method:: register_callback(log_level, fn, criteria=None):
+
+    :param log_level: The log level expression the callback should act on
+    :param fn: the function to call
+    :param criteria: a dictionary of values providing additional matching criteria before the callback is called
+
+The callback takes arguments in the form of the log level and a criteria dictionary. The log level may be of the following forms:
+
+* ``'INFO'``, ``'ERROR'``, ``'DEBUG'``, etc - the callback is only called when the exact log level message is used
+
+* ``'<=INFO'``, ``'>DEBUG'``, ``'>=WARNING'``, etc - parameterized callbacks, allowing the callback to execute in greater than or less than the desired log level
+
+* ``'*'`` - the callback is called regardless of log level
+
+For additional filtering requirements you may also use the ``criteria`` parameter, in which the criteria **must be a subset** of the ``extras`` originally passed into the logging method of choice.
+
+For example:
+
+::
+
+    {'a': 1} subset of {'a': 1, 'b': 2, 'c': 3}
+
+Both the log level and criteria are considered before executing the callback, basic usage is as follows:
+
+::
+
+    >>> from scutils.log_factory import LogFactory
+    >>> logger = LogFactory.get_instance()
+    >>> def call_me(message, extras):
+    ...   print("callback!", message, extras)
+    ...
+    >>> logger.register_callback('>=INFO', call_me)
+    >>> logger.debug("no callback")
+    >>> logger.info("check callback")
+    2017-02-01 15:19:48,466 [scrapy-cluster] INFO: check callback
+    ('callback!', 'check callback', {})
+
+In this example both the log message was written, the callback was called, and the three values were printed.
+
+.. note:: Your callback function must be declared outside of your Class scope, or use the ``@staticmethod`` decorator. Typically this means putting the function at the top of your python file outside of any class declarations.
+
 Example
 -------
 
@@ -152,13 +196,29 @@ Add the following python code to a new file, or use the script located at ``util
     args = vars(parser.parse_args())
     logger = LogFactory.get_instance(level=args['log_level'], stdout=args['log_file'],
                         json=args['log_json'], include_extra=args['include_extra'])
+
+    my_var = 1
+
+    def the_callback(log_message, log_extras):
+        global my_var
+        my_var += 5
+
+    def the_callback_2(log_message, log_extras):
+        global my_var
+        my_var *= 2
+
+    logger.register_callback('DEBUG', the_callback)
+    logger.register_callback('WARN', the_callback_2, {'key':"value"})
+
     logger.debug("debug output 1")
-    logger.warn("warn output", extra={"key":"value"})
+    logger.warn("warn output", extra={"key":"value", "key2":"value2"})
+    logger.warn("warn output 2")
     logger.debug("debug output 2")
     logger.critical("critical fault, closing")
     logger.debug("debug output 3")
     sum = 2 + 2
     logger.info("Info output closing.", extra={"sum":sum})
+    logger.error("Final var value", extra={"value": my_var})
 
 Let's assume you now have a file named ``example_lf.py``, run the following commands:
 
@@ -181,21 +241,25 @@ Let's assume you now have a file named ``example_lf.py``, run the following comm
 
     $ python example_lf.py --log-level DEBUG
     # Should write all log messages above
-    2015-11-17 16:49:06,957 [scrapy-cluster] DEBUG: Logging to stdout
-    2015-11-17 16:49:06,958 [scrapy-cluster] DEBUG: debug output 1
-    2015-11-17 16:49:06,958 [scrapy-cluster] WARNING: warn output
-    2015-11-17 16:49:06,958 [scrapy-cluster] DEBUG: debug output 2
-    2015-11-17 16:49:06,958 [scrapy-cluster] CRITICAL: critical fault, closing
-    2015-11-17 16:49:06,958 [scrapy-cluster] DEBUG: debug output 3
-    2015-11-17 16:49:06,958 [scrapy-cluster] INFO: Info output closing.
+    2017-02-01 15:27:48,814 [scrapy-cluster] DEBUG: Logging to stdout
+    2017-02-01 15:27:48,814 [scrapy-cluster] DEBUG: debug output 1
+    2017-02-01 15:27:48,814 [scrapy-cluster] WARNING: warn output
+    2017-02-01 15:27:48,814 [scrapy-cluster] WARNING: warn output 2
+    2017-02-01 15:27:48,814 [scrapy-cluster] DEBUG: debug output 2
+    2017-02-01 15:27:48,814 [scrapy-cluster] CRITICAL: critical fault, closing
+    2017-02-01 15:27:48,814 [scrapy-cluster] DEBUG: debug output 3
+    2017-02-01 15:27:48,814 [scrapy-cluster] INFO: Info output closing.
+    2017-02-01 15:27:48,814 [scrapy-cluster] ERROR: Final var value
 
 ::
 
     $ python example_lf.py --log-level INFO --log-json
     # Should log json object of "INFO" level or higher
-    {"message": "warn output", "logger": "scrapy-cluster", "timestamp": "2015-11-17T21:52:28.407833Z", "key": "value", "level": "WARNING"}
-    {"message": "critical fault, closing", "logger": "scrapy-cluster", "timestamp": "2015-11-17T21:52:28.408323Z", "level": "CRITICAL"}
-    {"message": "Info output closing.", "sum": 4, "logger": "scrapy-cluster", "timestamp": "2015-11-17T21:52:28.408421Z", "level": "INFO"}
+    {"message": "warn output", "key2": "value2", "logger": "scrapy-cluster", "timestamp": "2017-02-01T20:29:24.548895Z", "key": "value", "level": "WARNING"}
+    {"message": "warn output 2", "logger": "scrapy-cluster", "timestamp": "2017-02-01T20:29:24.549302Z", "level": "WARNING"}
+    {"message": "critical fault, closing", "logger": "scrapy-cluster", "timestamp": "2017-02-01T20:29:24.549420Z", "level": "CRITICAL"}
+    {"message": "Info output closing.", "sum": 4, "logger": "scrapy-cluster", "timestamp": "2017-02-01T20:29:24.549510Z", "level": "INFO"}
+    {"message": "Final var value", "logger": "scrapy-cluster", "timestamp": "2017-02-01T20:29:24.549642Z", "level": "ERROR", "value": 2}
 
 Notice that the extra dictionary object we passed into the two logs above is now in our json logging output
 
@@ -204,16 +268,24 @@ Notice that the extra dictionary object we passed into the two logs above is now
     $ python example_lf.py --log-level CRITICAL --log-json --log-file
     # Should log only one critical message to our file located at logs/
     $ tail logs/main.log
-    {"message": "critical fault, closing", "logger": "scrapy-cluster", "timestamp": "2015-11-17T21:56:28.318056Z", "level": "CRITICAL"}
+    {"message": "critical fault, closing", "logger": "scrapy-cluster", "timestamp": "2017-02-01T20:30:05.484337Z", "level": "CRITICAL"}
 
 You can also use the ``include_extra`` flag when instantiating the logger to print the dictionary even if you are not logging via json.
 
 ::
 
-    $ python example_lf.py -ie
-    2017-01-08 22:10:45,491 [scrapy-cluster] WARNING: warn output {'key': 'value'}
-    2017-01-08 22:10:45,492 [scrapy-cluster] CRITICAL: critical fault, closing
-    2017-01-08 22:10:45,492 [scrapy-cluster] INFO: Info output closing. {'sum': 4}
+    $ python example_lf.py -ll DEBUG -ie
+    2017-02-01 15:31:07,284 [scrapy-cluster] DEBUG: Logging to stdout
+    2017-02-01 15:31:07,284 [scrapy-cluster] DEBUG: debug output 1
+    2017-02-01 15:31:07,284 [scrapy-cluster] WARNING: warn output {'key2': 'value2', 'key': 'value'}
+    2017-02-01 15:31:07,284 [scrapy-cluster] WARNING: warn output 2
+    2017-02-01 15:31:07,284 [scrapy-cluster] DEBUG: debug output 2
+    2017-02-01 15:31:07,284 [scrapy-cluster] CRITICAL: critical fault, closing
+    2017-02-01 15:31:07,284 [scrapy-cluster] DEBUG: debug output 3
+    2017-02-01 15:31:07,284 [scrapy-cluster] INFO: Info output closing. {'sum': 4}
+    2017-02-01 15:31:07,285 [scrapy-cluster] ERROR: Final var value {'value': 22}
+
+Notice here that both our ``DEBUG`` callback was called three times, and the single ``WARN`` callback was called once, causing our final ``my_var`` variable to equal ``22``.
 
 ----
 

--- a/utils/examples/example_lf.py
+++ b/utils/examples/example_lf.py
@@ -16,10 +16,26 @@ parser.add_argument('-ie', '--include-extra', action='store_const', const=True,
 args = vars(parser.parse_args())
 logger = LogFactory.get_instance(level=args['log_level'], stdout=args['log_file'],
                     json=args['log_json'], include_extra=args['include_extra'])
+
+my_var = 1
+
+def the_callback(log_message, log_extras):
+    global my_var
+    my_var += 5
+
+def the_callback_2(log_message, log_extras):
+    global my_var
+    my_var *= 2
+
+logger.register_callback('DEBUG', the_callback)
+logger.register_callback('WARN', the_callback_2, {'key':"value"})
+
 logger.debug("debug output 1")
-logger.warn("warn output", extra={"key":"value"})
+logger.warn("warn output", extra={"key":"value", "key2":"value2"})
+logger.warn("warn output 2")
 logger.debug("debug output 2")
 logger.critical("critical fault, closing")
 logger.debug("debug output 3")
 sum = 2 + 2
 logger.info("Info output closing.", extra={"sum":sum})
+logger.error("Final var value", extra={"value": my_var})

--- a/utils/scutils/log_factory.py
+++ b/utils/scutils/log_factory.py
@@ -86,7 +86,7 @@ class LogCallbackMixin:
             if unmatched_criteria:
                 continue
             else:
-                cb(self, log_message, log_extra)
+                cb(log_message, log_extra)
 
 class LogObject(object, LogCallbackMixin):
     '''

--- a/utils/scutils/log_factory.py
+++ b/utils/scutils/log_factory.py
@@ -1,4 +1,5 @@
 from builtins import object
+from collections import OrderedDict
 import logging
 import sys
 import datetime
@@ -24,8 +25,70 @@ class LogFactory(object):
 
         return self._instance
 
+class LogCallbackMixin:
+    def parse_log_level(self, log_level):
+        MIN_LOG_LEVEL = self.level_dict['DEBUG']
+        MAX_LOG_LEVEL = self.level_dict['CRITICAL']
 
-class LogObject(object):
+        chrs = log_level[:2]
+        if chrs == '<=':
+            log_level = log_level[2:]
+            log_level_n = self.level_dict[log_level]
+            r = range(MIN_LOG_LEVEL, log_level_n + 1)
+        elif chrs.startswith('<'):
+            log_level = log_level[1:]
+            log_level_n = self.level_dict[log_level]
+            r = range(MIN_LOG_LEVEL, log_level_n)
+        elif chrs == '>=':
+            log_level = log_level[2:]
+            log_level_n = self.level_dict[log_level]
+            r = range(log_level_n, MAX_LOG_LEVEL+1)
+        elif chrs.startswith('>'):
+            log_level = log_level[1:]
+            log_level_n = self.level_dict[log_level]
+            r = range(log_level_n+1, MAX_LOG_LEVEL+1)
+        elif chrs.startswith('='):
+            log_level = log_level[1:]
+            log_level_n = self.level_dict[log_level]
+            r = range(log_level_n, log_level_n+1)
+        elif chrs == '*':
+            r = range(MIN_LOG_LEVEL, MAX_LOG_LEVEL+1)
+        else:
+            log_level_n = self.level_dict[log_level]
+            r = range(log_level_n, log_level_n+1)
+
+        return r
+
+    def is_subdict(self, a,b):
+        '''
+        Return True if a is a subdict of b
+        '''
+        return all((k in b and b[k]==v) for k,v in a.iteritems())
+
+
+    def register_callback(self, log_level, fn, criteria=None):
+        criteria = criteria or {}
+
+        num_to_level_map = {v: k for k, v in self.level_dict.iteritems()}
+        log_range = self.parse_log_level(log_level)
+
+        for log_n in log_range:
+            level = num_to_level_map[log_n]
+            self.callbacks[level].append((fn, criteria))
+
+
+    def fire_callbacks(self, log_level, log_message=None, log_extra=None):
+        log_extra = log_extra or {}
+
+        callbacks = self.callbacks[log_level]
+        for cb, criteria in callbacks:
+            unmatched_criteria = criteria and not self.is_subdict(criteria, log_extra)
+            if unmatched_criteria:
+                continue
+            else:
+                cb(self, log_message, log_extra)
+
+class LogObject(object, LogCallbackMixin):
     '''
     Easy wrapper for writing json logs to a rotating file log
     '''
@@ -66,6 +129,13 @@ class LogObject(object):
         self.log_level = level
         self.format_string = format
         self.include_extra = include_extra
+        self.callbacks = OrderedDict([
+            ("DEBUG", []),
+            ("INFO", []),
+            ("WARNING", []),
+            ("ERROR", []),
+            ("CRITICAL", []),
+        ])
 
         if stdout:
             # set up to std out
@@ -128,6 +198,7 @@ class LogObject(object):
         if self.level_dict['DEBUG'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "DEBUG")
             self._write_message(message, extras)
+            self.fire_callbacks('DEBUG', message, extra)
 
     def info(self, message, extra={}):
         '''
@@ -139,6 +210,7 @@ class LogObject(object):
         if self.level_dict['INFO'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "INFO")
             self._write_message(message, extras)
+            self.fire_callbacks('INFO', message, extra)
 
     def warn(self, message, extra={}):
         '''
@@ -159,6 +231,7 @@ class LogObject(object):
         if self.level_dict['WARNING'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "WARNING")
             self._write_message(message, extras)
+            self.fire_callbacks('WARNING', message, extra)
 
     def error(self, message, extra={}):
         '''
@@ -170,6 +243,7 @@ class LogObject(object):
         if self.level_dict['ERROR'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "ERROR")
             self._write_message(message, extras)
+            self.fire_callbacks('ERROR', message, extra)
 
     def critical(self, message, extra={}):
         '''
@@ -181,6 +255,7 @@ class LogObject(object):
         if self.level_dict['CRITICAL'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "CRITICAL")
             self._write_message(message, extras)
+            self.fire_callbacks('CRITICAL', message, extra)
 
     def _write_message(self, message, extra):
         '''

--- a/utils/tests/test_log_factory.py
+++ b/utils/tests/test_log_factory.py
@@ -107,8 +107,6 @@ class TestLogJSONFile(TestCase):
         self.logger.info("Test log")
         with open(self.test_file + '.log', 'r') as f:
             read_data = f.read()
-            print('read_data ')
-            print(read_data )
             the_dict = json.loads(read_data)
             six.assertCountEqual(self, the_dict, {
                 "message": "Test log",

--- a/utils/tests/test_log_factory.py
+++ b/utils/tests/test_log_factory.py
@@ -126,3 +126,184 @@ class TestLogJSONFile(TestCase):
     def tearDown(self):
         os.remove(self.test_file + '.log')
         os.remove(self.test_file + '.lock')
+
+class TestLogCallbacks(TestCase):
+    def setUp(self):
+        self.logger = LogObject(name='test', json=True,
+                                dir='.', level='INFO', stdout=False,
+                                file='test.log')
+        self.test_file = './test'
+
+    def test_log_callbacks_integration(self):
+        def add_1(log_obj, log_message=None, log_extra=None):
+            log_obj.x += 1
+
+        def negate(log_obj, log_message=None, log_extra=None):
+            log_obj.x *= -1
+
+        def multiply_5(log_obj, log_message=None, log_extra=None):
+            log_obj.x *= 5
+
+        self.logger.register_callback('<=INFO', add_1, {'key': 'val1'})
+        self.logger.register_callback('<=INFO', negate, {'key': 'val2'})
+        self.logger.register_callback('<=INFO', multiply_5)
+
+        self.logger.x = 1
+        self.logger.log_level = 'INFO'
+        self.logger.info('info message')
+        self.assertEqual(5, self.logger.x)
+
+        self.logger.x = 1
+        self.logger.log_level = 'INFO'
+        self.logger.info('info message', extra={'key': 'val1'})
+        self.assertEqual(10, self.logger.x)
+
+        self.logger.x = 1
+        self.logger.log_level = 'INFO'
+        self.logger.info('info message', extra={'key': 'val2'})
+        self.assertEqual(-5, self.logger.x)
+
+        # Callback shouldn't fire
+        self.logger.x = 1
+        self.logger.log_level = 'CRITICAL'
+        self.logger.info('info message')
+        self.assertEqual(1, self.logger.x)
+
+        # Callback shouldn't fire
+        self.logger.x = 1
+        self.logger.log_level = 'INFO'
+        self.logger.warning('warning message')
+        self.assertEqual(1, self.logger.x)
+
+    def test_parse_log_level(self):
+        log_range = self.logger.parse_log_level("<=INFO")
+        self.assertEqual([0,1], log_range)
+
+        log_range = self.logger.parse_log_level("<INFO")
+        self.assertEqual([0], log_range)
+
+        log_range = self.logger.parse_log_level(">=WARNING")
+        self.assertEqual([2,3,4], log_range)
+
+        log_range = self.logger.parse_log_level(">WARN")
+        self.assertEqual([3,4], log_range)
+
+        log_range = self.logger.parse_log_level("=INFO")
+        self.assertEqual([1], log_range)
+
+        log_range = self.logger.parse_log_level("CRITICAL")
+        self.assertEqual([4], log_range)
+
+    def test_register_callback(self):
+        def add_1(log_obj, log_message=None, log_extra=None):
+            pass
+
+        def add_2(log_obj, log_message=None, log_extra=None):
+            pass
+
+        def add_3(log_obj, log_message=None, log_extra=None):
+            pass
+
+        def add_4(log_obj, log_message=None, log_extra=None):
+            pass
+
+        self.logger.register_callback('>=INFO', add_1)
+        self.logger.register_callback('<=WARN', add_2)
+        self.logger.register_callback('ERROR', add_3)
+        self.logger.register_callback('*', add_4)
+
+        callbacks = [cb for cb,criteria in self.logger.callbacks['DEBUG']]
+        self.assertEqual([add_2, add_4], callbacks)
+
+        callbacks = [cb for cb,criteria in self.logger.callbacks['INFO']]
+        self.assertEqual([add_1, add_2, add_4], callbacks)
+
+        callbacks = [cb for cb,criteria in self.logger.callbacks['WARNING']]
+        self.assertEqual([add_1, add_2, add_4], callbacks)
+
+        callbacks = [cb for cb,criteria in self.logger.callbacks['ERROR']]
+        self.assertEqual([add_1, add_3, add_4], callbacks)
+
+        callbacks = [cb for cb,criteria in self.logger.callbacks['CRITICAL']]
+        self.assertEqual([add_1, add_4], callbacks)
+
+    def test_fire_callbacks_basic_1(self):
+        def add_1(log_obj, log_message=None, log_extra=None):
+            log_obj.x += 1
+
+        def negate(log_obj, log_message=None, log_extra=None):
+            log_obj.x *= -1
+
+        def multiply_5(log_obj, log_message=None, log_extra=None):
+            log_obj.x *= 5
+
+        self.logger.register_callback('<=INFO', add_1)
+        self.logger.register_callback('INFO', negate)
+        self.logger.register_callback('<CRITICAL', add_1)
+        self.logger.register_callback('>DEBUG', multiply_5)
+
+        self.logger.x = 0
+        self.logger.log_level = 'DEBUG'
+        self.logger.fire_callbacks('DEBUG')
+        self.assertEqual(2, self.logger.x)
+
+        self.logger.x = 0
+        self.logger.log_level = 'INFO'
+        self.logger.fire_callbacks('INFO')
+        self.assertEqual(0, self.logger.x)
+
+        self.logger.x = 0
+        self.logger.log_level = 'WARNING'
+        self.logger.fire_callbacks('WARNING')
+        self.assertEqual(5, self.logger.x)
+
+        self.logger.x = 0
+        self.logger.log_level = 'ERROR'
+        self.logger.fire_callbacks('ERROR')
+        self.assertEqual(5, self.logger.x)
+
+        self.logger.x = 0
+        self.logger.log_level = 'CRITICAL'
+        self.logger.fire_callbacks('CRITICAL')
+        self.assertEqual(0, self.logger.x)
+
+    def test_fire_callbacks_basic_2(self):
+        def add_1(log_obj, log_message=None, log_extra=None):
+            log_obj.x += 1
+
+        def negate(log_obj, log_message=None, log_extra=None):
+            log_obj.x *= -1
+
+        def multiply_5(log_obj, log_message=None, log_extra=None):
+            log_obj.x *= 5
+
+        self.logger.register_callback('>DEBUG', add_1)
+        self.logger.register_callback('=WARNING', negate)
+        self.logger.register_callback('<INFO', add_1)
+        self.logger.register_callback('>=INFO', multiply_5)
+        self.logger.register_callback('*', add_1)
+
+        self.logger.x = 0
+        self.logger.log_level = 'DEBUG'
+        self.logger.fire_callbacks('DEBUG')
+        self.assertEqual(2, self.logger.x)
+
+        self.logger.x = 0
+        self.logger.log_level = 'INFO'
+        self.logger.fire_callbacks('INFO')
+        self.assertEqual(6, self.logger.x)
+
+        self.logger.x = 0
+        self.logger.log_level = 'WARNING'
+        self.logger.fire_callbacks('WARNING')
+        self.assertEqual(-4, self.logger.x)
+
+        self.logger.x = 0
+        self.logger.log_level = 'ERROR'
+        self.logger.fire_callbacks('ERROR')
+        self.assertEqual(6, self.logger.x)
+
+        self.logger.x = 0
+        self.logger.log_level = 'CRITICAL'
+        self.logger.fire_callbacks('CRITICAL')
+        self.assertEqual(6, self.logger.x)

--- a/utils/tests/test_log_factory.py
+++ b/utils/tests/test_log_factory.py
@@ -306,3 +306,7 @@ class TestLogCallbacks(TestCase):
         self.logger.log_level = 'CRITICAL'
         self.logger.fire_callbacks('CRITICAL')
         self.assertEqual(6, self.logger.x)
+
+    def tearDown(self):
+        os.remove('main.log')
+        os.remove('main.lock')

--- a/utils/tests/test_log_factory.py
+++ b/utils/tests/test_log_factory.py
@@ -132,16 +132,17 @@ class TestLogCallbacks(TestCase):
         self.logger = LogObject(name='test', json=True,
                                 dir='.', level='INFO', stdout=False,
                                 )
+        self.logger.x = 1
 
     def test_log_callbacks_integration(self):
-        def add_1(log_obj, log_message=None, log_extra=None):
-            log_obj.x += 1
+        def add_1(log_message=None, log_extra=None):
+            self.logger.x += 1
 
-        def negate(log_obj, log_message=None, log_extra=None):
-            log_obj.x *= -1
+        def negate(log_message=None, log_extra=None):
+            self.logger.x *= -1
 
-        def multiply_5(log_obj, log_message=None, log_extra=None):
-            log_obj.x *= 5
+        def multiply_5(log_message=None, log_extra=None):
+            self.logger.x *= 5
 
         self.logger.register_callback('<=INFO', add_1, {'key': 'val1'})
         self.logger.register_callback('<=INFO', negate, {'key': 'val2'})
@@ -227,14 +228,14 @@ class TestLogCallbacks(TestCase):
         self.assertEqual([add_1, add_4], callbacks)
 
     def test_fire_callbacks_basic_1(self):
-        def add_1(log_obj, log_message=None, log_extra=None):
-            log_obj.x += 1
+        def add_1(log_message=None, log_extra=None):
+            self.logger.x += 1
 
-        def negate(log_obj, log_message=None, log_extra=None):
-            log_obj.x *= -1
+        def negate(log_message=None, log_extra=None):
+            self.logger.x *= -1
 
-        def multiply_5(log_obj, log_message=None, log_extra=None):
-            log_obj.x *= 5
+        def multiply_5(log_message=None, log_extra=None):
+            self.logger.x *= 5
 
         self.logger.register_callback('<=INFO', add_1)
         self.logger.register_callback('INFO', negate)
@@ -267,14 +268,14 @@ class TestLogCallbacks(TestCase):
         self.assertEqual(0, self.logger.x)
 
     def test_fire_callbacks_basic_2(self):
-        def add_1(log_obj, log_message=None, log_extra=None):
-            log_obj.x += 1
+        def add_1(log_message=None, log_extra=None):
+            self.logger.x += 1
 
-        def negate(log_obj, log_message=None, log_extra=None):
-            log_obj.x *= -1
+        def negate(log_message=None, log_extra=None):
+            self.logger.x *= -1
 
-        def multiply_5(log_obj, log_message=None, log_extra=None):
-            log_obj.x *= 5
+        def multiply_5(log_message=None, log_extra=None):
+            self.logger.x *= 5
 
         self.logger.register_callback('>DEBUG', add_1)
         self.logger.register_callback('=WARNING', negate)

--- a/utils/tests/test_log_factory.py
+++ b/utils/tests/test_log_factory.py
@@ -107,6 +107,8 @@ class TestLogJSONFile(TestCase):
         self.logger.info("Test log")
         with open(self.test_file + '.log', 'r') as f:
             read_data = f.read()
+            print('read_data ')
+            print(read_data )
             the_dict = json.loads(read_data)
             six.assertCountEqual(self, the_dict, {
                 "message": "Test log",
@@ -131,8 +133,7 @@ class TestLogCallbacks(TestCase):
     def setUp(self):
         self.logger = LogObject(name='test', json=True,
                                 dir='.', level='INFO', stdout=False,
-                                file='test.log')
-        self.test_file = './test'
+                                )
 
     def test_log_callbacks_integration(self):
         def add_1(log_obj, log_message=None, log_extra=None):

--- a/utils/tests/test_log_factory.py
+++ b/utils/tests/test_log_factory.py
@@ -308,6 +308,18 @@ class TestLogCallbacks(TestCase):
         self.logger.fire_callbacks('CRITICAL')
         self.assertEqual(6, self.logger.x)
 
+    def test_preserve_data(self):
+        message = "THIS IS A TEST"
+        extras = {"key": "value", 'a': [1, 2, 3]}
+
+        def cb(log_message=None, log_extra=None):
+            self.assertEquals(log_message, message)
+            self.assertEquals(log_extra, extras)
+
+        self.logger.register_callback('>DEBUG', cb)
+        self.logger.log_level = 'INFO'
+        self.logger.info(message, extras)
+
     def tearDown(self):
         os.remove('main.log')
         os.remove('main.lock')


### PR DESCRIPTION
This PR provides a starting point for registering callbacks using the `LogFactory`. This PR addresses Issue #91 

## Usage

Given a logging object `logger`, you can register a callback via

```python
logger.register_callback(log_level, callback_function, optional_criteria_dict)
```

Some examples:

    logger.register_callback('ERROR', report)

Explanation: The callback function `report` will fire when the `.error()` logging method is called

    logger.register_callback('<=INFO', add_1, {'key': 'val1'})

Explanation: The callback function `add_1` will fire when `.debug()` or `.info()` are called AND the `{'key': 'val1'} is a subdict of the `extras` passed to the logging functions

    logger.register_callback('>INFO', negate, {'key': 'val2'})

Explanation: The callback function `negate` will fire when `.warning()`, `.error()`, or `.critical()` are called AND `{'key': 'val2'}` is a subdict of `extras` passed to the logging functions.

    logger.register_callback('*', always_fire)

Explanation: The callback function `always_fire` will fire for all log levels with no concern of the `extras` dict passed to the logging functions.
  

## Testing

```bash
$ python -m unittest tests.test_log_factory
```

## Notes

The callbacks respect the log level. If the log level for a logger is CRITICAL then a `.debug()` invocation will not trigger the callbacks registered for CRITICAL. 