### PR TITLE
Limit number of crawled pages per domain

### DIFF
--- a/crawler/crawling/redis_page_per_host_filter.py
+++ b/crawler/crawling/redis_page_per_host_filter.py
@@ -1,0 +1,39 @@
+from scrapy.dupefilters import BaseDupeFilter
+
+
+class PagePerHostFilter(BaseDupeFilter):
+    '''
+    Redis-based request duplication filter
+    '''
+    def __init__(self, server, key, page_limit, timeout):
+        '''
+        Initialize duplication filter
+
+        @param server: the redis connection
+        @param key: the key to store the fingerprints
+        @param timeout: number of seconds a given key will remain once idle
+        '''
+        self.server = server
+        self.key = key
+        self.page_limit = page_limit
+        self.timeout = timeout
+
+    def reached_page_limit(self, request):
+        c_id = request.meta['crawlid']
+
+        page_count = self.server.incr(self.key + ":" + c_id)
+        self.server.expire(self.key + ":" + c_id, self.timeout)
+
+        return page_count >= self.page_limit
+
+    def close(self, reason):
+        '''
+        Delete data on close. Called by scrapy's scheduler
+        '''
+        self.clear()
+
+    def clear(self):
+        '''
+        Clears fingerprints data
+        '''
+        self.server.delete(self.key)

--- a/crawler/crawling/settings.py
+++ b/crawler/crawling/settings.py
@@ -38,6 +38,12 @@ QUEUE_MODERATED = True
 # how long we want the duplicate timeout queues to stick around in seconds
 DUPEFILTER_TIMEOUT = 600
 
+# how many pages to we want to crawl for each host
+PAGE_PER_HOST_LIMIT = None
+
+# how long we want the page per host limit to stick around in seconds
+PAGE_PER_HOST_LIMIT_TIMEOUT = 600
+
 # how often to refresh the ip address of the scheduler
 SCHEDULER_IP_REFRESH = 60
 

--- a/docs/topics/crawler/settings.rst
+++ b/docs/topics/crawler/settings.rst
@@ -116,6 +116,20 @@ Default: ``600``
 
 Number of seconds to keep **crawlid** specific duplication filters around after the latest crawl with that id has been conducted. Putting this setting too low may allow crawl jobs to crawl the same page due to the duplication filter being wiped out.
 
+.. _page_per_host_filter:
+
+**PAGE_PER_HOST_LIMIT**
+
+Default: ``None``
+
+The maximum number of pages to crawl for each domain.
+
+**PAGE_PER_HOST_LIMIT_TIMEOUT**
+
+Default: ``600``
+
+Number of seconds to keep **crawlid** specific maximum crawled pages limit filters around after the latest crawl with that id has been conducted. Putting this setting too low may allow crawl jobs to crawl more pages than expected due to the pages limit filter being wiped out.
+
 **SCHEDULER_IP_REFRESH**
 
 Default: ``60``


### PR DESCRIPTION
Pull request for #103 
Added the ability to set a maximum page limit for urls.
A crawler would crawl through pages in the domain until it reaches that limit.
The page limit will be saved in Redis as a new key for each crawlid until it will become expired.

The commit will add the following changes:
1. Added a new filter for handling this behavior in crawler/crawling/redis_page_per_host_filter.py
2. distributed_scheduler will use this new class during enqueue_request
3. Added default settings for this feature in crawler/crawling/settings.py
4. Added offline unit tests for this feature
5. Added documentation for this feature in docs/topics/crawler/settings.rst