### PR TITLE
Make scuitls Logger callbacks Python 2 and Python 3 compatible

### DIFF
--- a/utils/scutils/log_factory.py
+++ b/utils/scutils/log_factory.py
@@ -67,19 +67,19 @@ class LogCallbackHandler:
             log_level_n = self.logger.level_dict[log_level]
             r = range(log_level_n, log_level_n+1)
 
-        return r
+        return list(r)
 
     def is_subdict(self, a,b):
         '''
         Return True if a is a subdict of b
         '''
-        return all((k in b and b[k]==v) for k,v in a.iteritems())
+        return all((k in b and b[k]==v) for k,v in a.items())
 
 
     def register_callback(self, log_level, fn, criteria=None):
         criteria = criteria or {}
 
-        num_to_level_map = {v: k for k, v in self.logger.level_dict.iteritems()}
+        num_to_level_map = {v: k for k, v in self.logger.level_dict.items()}
         log_range = self.parse_log_level(log_level)
 
         for log_n in log_range:

--- a/utils/scutils/log_factory.py
+++ b/utils/scutils/log_factory.py
@@ -25,36 +25,46 @@ class LogFactory(object):
 
         return self._instance
 
-class LogCallbackMixin:
+class LogCallbackHandler:
+    def __init__(self, logger):
+        self.logger = logger
+        self.callbacks = OrderedDict([
+            ("DEBUG", []),
+            ("INFO", []),
+            ("WARNING", []),
+            ("ERROR", []),
+            ("CRITICAL", []),
+        ])
+
     def parse_log_level(self, log_level):
-        MIN_LOG_LEVEL = self.level_dict['DEBUG']
-        MAX_LOG_LEVEL = self.level_dict['CRITICAL']
+        MIN_LOG_LEVEL = self.logger.level_dict['DEBUG']
+        MAX_LOG_LEVEL = self.logger.level_dict['CRITICAL']
 
         chrs = log_level[:2]
         if chrs == '<=':
             log_level = log_level[2:]
-            log_level_n = self.level_dict[log_level]
+            log_level_n = self.logger.level_dict[log_level]
             r = range(MIN_LOG_LEVEL, log_level_n + 1)
         elif chrs.startswith('<'):
             log_level = log_level[1:]
-            log_level_n = self.level_dict[log_level]
+            log_level_n = self.logger.level_dict[log_level]
             r = range(MIN_LOG_LEVEL, log_level_n)
         elif chrs == '>=':
             log_level = log_level[2:]
-            log_level_n = self.level_dict[log_level]
+            log_level_n = self.logger.level_dict[log_level]
             r = range(log_level_n, MAX_LOG_LEVEL+1)
         elif chrs.startswith('>'):
             log_level = log_level[1:]
-            log_level_n = self.level_dict[log_level]
+            log_level_n = self.logger.level_dict[log_level]
             r = range(log_level_n+1, MAX_LOG_LEVEL+1)
         elif chrs.startswith('='):
             log_level = log_level[1:]
-            log_level_n = self.level_dict[log_level]
+            log_level_n = self.logger.level_dict[log_level]
             r = range(log_level_n, log_level_n+1)
         elif chrs == '*':
             r = range(MIN_LOG_LEVEL, MAX_LOG_LEVEL+1)
         else:
-            log_level_n = self.level_dict[log_level]
+            log_level_n = self.logger.level_dict[log_level]
             r = range(log_level_n, log_level_n+1)
 
         return r
@@ -69,7 +79,7 @@ class LogCallbackMixin:
     def register_callback(self, log_level, fn, criteria=None):
         criteria = criteria or {}
 
-        num_to_level_map = {v: k for k, v in self.level_dict.iteritems()}
+        num_to_level_map = {v: k for k, v in self.logger.level_dict.iteritems()}
         log_range = self.parse_log_level(log_level)
 
         for log_n in log_range:
@@ -88,7 +98,7 @@ class LogCallbackMixin:
             else:
                 cb(log_message, log_extra)
 
-class LogObject(object, LogCallbackMixin):
+class LogObject(object):
     '''
     Easy wrapper for writing json logs to a rotating file log
     '''
@@ -127,15 +137,9 @@ class LogObject(object, LogCallbackMixin):
         self.logger.propagate = propagate
         self.json = json
         self.log_level = level
+        self.cb_handler = LogCallbackHandler(self)
         self.format_string = format
         self.include_extra = include_extra
-        self.callbacks = OrderedDict([
-            ("DEBUG", []),
-            ("INFO", []),
-            ("WARNING", []),
-            ("ERROR", []),
-            ("CRITICAL", []),
-        ])
 
         if stdout:
             # set up to std out
@@ -198,7 +202,7 @@ class LogObject(object, LogCallbackMixin):
         if self.level_dict['DEBUG'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "DEBUG")
             self._write_message(message, extras)
-            self.fire_callbacks('DEBUG', message, extra)
+            self.cb_handler.fire_callbacks('DEBUG', message, extra)
 
     def info(self, message, extra={}):
         '''
@@ -210,7 +214,7 @@ class LogObject(object, LogCallbackMixin):
         if self.level_dict['INFO'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "INFO")
             self._write_message(message, extras)
-            self.fire_callbacks('INFO', message, extra)
+            self.cb_handler.fire_callbacks('INFO', message, extra)
 
     def warn(self, message, extra={}):
         '''
@@ -231,7 +235,7 @@ class LogObject(object, LogCallbackMixin):
         if self.level_dict['WARNING'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "WARNING")
             self._write_message(message, extras)
-            self.fire_callbacks('WARNING', message, extra)
+            self.cb_handler.fire_callbacks('WARNING', message, extra)
 
     def error(self, message, extra={}):
         '''
@@ -243,7 +247,7 @@ class LogObject(object, LogCallbackMixin):
         if self.level_dict['ERROR'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "ERROR")
             self._write_message(message, extras)
-            self.fire_callbacks('ERROR', message, extra)
+            self.cb_handler.fire_callbacks('ERROR', message, extra)
 
     def critical(self, message, extra={}):
         '''
@@ -255,7 +259,7 @@ class LogObject(object, LogCallbackMixin):
         if self.level_dict['CRITICAL'] >= self.level_dict[self.log_level]:
             extras = self.add_extras(extra, "CRITICAL")
             self._write_message(message, extras)
-            self.fire_callbacks('CRITICAL', message, extra)
+            self.cb_handler.fire_callbacks('CRITICAL', message, extra)
 
     def _write_message(self, message, extra):
         '''

--- a/utils/scutils/log_factory.py
+++ b/utils/scutils/log_factory.py
@@ -80,6 +80,10 @@ class LogCallbackHandler:
         criteria = criteria or {}
 
         num_to_level_map = {v: k for k, v in self.logger.level_dict.items()}
+
+        # Force normalization of WARN
+        num_to_level_map[2] = "WARNING"
+
         log_range = self.parse_log_level(log_level)
 
         for log_n in log_range:

--- a/utils/tests/test_argparse_helper.py
+++ b/utils/tests/test_argparse_helper.py
@@ -9,7 +9,12 @@ import sys
 
 # from http://stackoverflow.com/questions/4219717/how-to-assert-output-with-nosetest-unittest-in-python
 from contextlib import contextmanager
-from StringIO import StringIO
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 @contextmanager
 def captured_output():
     new_out, new_err = StringIO(), StringIO()

--- a/utils/tests/test_log_factory.py
+++ b/utils/tests/test_log_factory.py
@@ -144,9 +144,9 @@ class TestLogCallbacks(TestCase):
         def multiply_5(log_message=None, log_extra=None):
             self.logger.x *= 5
 
-        self.logger.register_callback('<=INFO', add_1, {'key': 'val1'})
-        self.logger.register_callback('<=INFO', negate, {'key': 'val2'})
-        self.logger.register_callback('<=INFO', multiply_5)
+        self.logger.cb_handler.register_callback('<=INFO', add_1, {'key': 'val1'})
+        self.logger.cb_handler.register_callback('<=INFO', negate, {'key': 'val2'})
+        self.logger.cb_handler.register_callback('<=INFO', multiply_5)
 
         self.logger.x = 1
         self.logger.log_level = 'INFO'
@@ -176,22 +176,22 @@ class TestLogCallbacks(TestCase):
         self.assertEqual(1, self.logger.x)
 
     def test_parse_log_level(self):
-        log_range = self.logger.parse_log_level("<=INFO")
+        log_range = self.logger.cb_handler.parse_log_level("<=INFO")
         self.assertEqual([0,1], log_range)
 
-        log_range = self.logger.parse_log_level("<INFO")
+        log_range = self.logger.cb_handler.parse_log_level("<INFO")
         self.assertEqual([0], log_range)
 
-        log_range = self.logger.parse_log_level(">=WARNING")
+        log_range = self.logger.cb_handler.parse_log_level(">=WARNING")
         self.assertEqual([2,3,4], log_range)
 
-        log_range = self.logger.parse_log_level(">WARN")
+        log_range = self.logger.cb_handler.parse_log_level(">WARN")
         self.assertEqual([3,4], log_range)
 
-        log_range = self.logger.parse_log_level("=INFO")
+        log_range = self.logger.cb_handler.parse_log_level("=INFO")
         self.assertEqual([1], log_range)
 
-        log_range = self.logger.parse_log_level("CRITICAL")
+        log_range = self.logger.cb_handler.parse_log_level("CRITICAL")
         self.assertEqual([4], log_range)
 
     def test_register_callback(self):
@@ -207,24 +207,24 @@ class TestLogCallbacks(TestCase):
         def add_4(log_obj, log_message=None, log_extra=None):
             pass
 
-        self.logger.register_callback('>=INFO', add_1)
-        self.logger.register_callback('<=WARN', add_2)
-        self.logger.register_callback('ERROR', add_3)
-        self.logger.register_callback('*', add_4)
+        self.logger.cb_handler.register_callback('>=INFO', add_1)
+        self.logger.cb_handler.register_callback('<=WARN', add_2)
+        self.logger.cb_handler.register_callback('ERROR', add_3)
+        self.logger.cb_handler.register_callback('*', add_4)
 
-        callbacks = [cb for cb,criteria in self.logger.callbacks['DEBUG']]
+        callbacks = [cb for cb,criteria in self.logger.cb_handler.callbacks['DEBUG']]
         self.assertEqual([add_2, add_4], callbacks)
 
-        callbacks = [cb for cb,criteria in self.logger.callbacks['INFO']]
+        callbacks = [cb for cb,criteria in self.logger.cb_handler.callbacks['INFO']]
         self.assertEqual([add_1, add_2, add_4], callbacks)
 
-        callbacks = [cb for cb,criteria in self.logger.callbacks['WARNING']]
+        callbacks = [cb for cb,criteria in self.logger.cb_handler.callbacks['WARNING']]
         self.assertEqual([add_1, add_2, add_4], callbacks)
 
-        callbacks = [cb for cb,criteria in self.logger.callbacks['ERROR']]
+        callbacks = [cb for cb,criteria in self.logger.cb_handler.callbacks['ERROR']]
         self.assertEqual([add_1, add_3, add_4], callbacks)
 
-        callbacks = [cb for cb,criteria in self.logger.callbacks['CRITICAL']]
+        callbacks = [cb for cb,criteria in self.logger.cb_handler.callbacks['CRITICAL']]
         self.assertEqual([add_1, add_4], callbacks)
 
     def test_fire_callbacks_basic_1(self):
@@ -237,34 +237,34 @@ class TestLogCallbacks(TestCase):
         def multiply_5(log_message=None, log_extra=None):
             self.logger.x *= 5
 
-        self.logger.register_callback('<=INFO', add_1)
-        self.logger.register_callback('INFO', negate)
-        self.logger.register_callback('<CRITICAL', add_1)
-        self.logger.register_callback('>DEBUG', multiply_5)
+        self.logger.cb_handler.register_callback('<=INFO', add_1)
+        self.logger.cb_handler.register_callback('INFO', negate)
+        self.logger.cb_handler.register_callback('<CRITICAL', add_1)
+        self.logger.cb_handler.register_callback('>DEBUG', multiply_5)
 
         self.logger.x = 0
         self.logger.log_level = 'DEBUG'
-        self.logger.fire_callbacks('DEBUG')
+        self.logger.cb_handler.fire_callbacks('DEBUG')
         self.assertEqual(2, self.logger.x)
 
         self.logger.x = 0
         self.logger.log_level = 'INFO'
-        self.logger.fire_callbacks('INFO')
+        self.logger.cb_handler.fire_callbacks('INFO')
         self.assertEqual(0, self.logger.x)
 
         self.logger.x = 0
         self.logger.log_level = 'WARNING'
-        self.logger.fire_callbacks('WARNING')
+        self.logger.cb_handler.fire_callbacks('WARNING')
         self.assertEqual(5, self.logger.x)
 
         self.logger.x = 0
         self.logger.log_level = 'ERROR'
-        self.logger.fire_callbacks('ERROR')
+        self.logger.cb_handler.fire_callbacks('ERROR')
         self.assertEqual(5, self.logger.x)
 
         self.logger.x = 0
         self.logger.log_level = 'CRITICAL'
-        self.logger.fire_callbacks('CRITICAL')
+        self.logger.cb_handler.fire_callbacks('CRITICAL')
         self.assertEqual(0, self.logger.x)
 
     def test_fire_callbacks_basic_2(self):
@@ -277,35 +277,35 @@ class TestLogCallbacks(TestCase):
         def multiply_5(log_message=None, log_extra=None):
             self.logger.x *= 5
 
-        self.logger.register_callback('>DEBUG', add_1)
-        self.logger.register_callback('=WARNING', negate)
-        self.logger.register_callback('<INFO', add_1)
-        self.logger.register_callback('>=INFO', multiply_5)
-        self.logger.register_callback('*', add_1)
+        self.logger.cb_handler.register_callback('>DEBUG', add_1)
+        self.logger.cb_handler.register_callback('=WARNING', negate)
+        self.logger.cb_handler.register_callback('<INFO', add_1)
+        self.logger.cb_handler.register_callback('>=INFO', multiply_5)
+        self.logger.cb_handler.register_callback('*', add_1)
 
         self.logger.x = 0
         self.logger.log_level = 'DEBUG'
-        self.logger.fire_callbacks('DEBUG')
+        self.logger.cb_handler.fire_callbacks('DEBUG')
         self.assertEqual(2, self.logger.x)
 
         self.logger.x = 0
         self.logger.log_level = 'INFO'
-        self.logger.fire_callbacks('INFO')
+        self.logger.cb_handler.fire_callbacks('INFO')
         self.assertEqual(6, self.logger.x)
 
         self.logger.x = 0
         self.logger.log_level = 'WARNING'
-        self.logger.fire_callbacks('WARNING')
+        self.logger.cb_handler.fire_callbacks('WARNING')
         self.assertEqual(-4, self.logger.x)
 
         self.logger.x = 0
         self.logger.log_level = 'ERROR'
-        self.logger.fire_callbacks('ERROR')
+        self.logger.cb_handler.fire_callbacks('ERROR')
         self.assertEqual(6, self.logger.x)
 
         self.logger.x = 0
         self.logger.log_level = 'CRITICAL'
-        self.logger.fire_callbacks('CRITICAL')
+        self.logger.cb_handler.fire_callbacks('CRITICAL')
         self.assertEqual(6, self.logger.x)
 
     def test_preserve_data(self):
@@ -316,7 +316,7 @@ class TestLogCallbacks(TestCase):
             self.assertEquals(log_message, message)
             self.assertEquals(log_extra, extras)
 
-        self.logger.register_callback('>DEBUG', cb)
+        self.logger.cb_handler.register_callback('>DEBUG', cb)
         self.logger.log_level = 'INFO'
         self.logger.info(message, extras)
 


### PR DESCRIPTION
I eliminated the Mixin style inheritance scheme between Logger and LogCallbackMixin and went with a more standard "has-a"  relationship.

I've verified the changes pass all tests in the utils directory for Python 2.7.13 and 3.5.3.

While this does not address the RedisPriorityQueue issue, I don't think it necessarily needs to be addressed yet to get scutils itself usable across python 2 and python 3.