### PR TITLE
add deactivate method to ThreadedCounter

### DIFF
--- a/utils/scutils/stats_collector.py
+++ b/utils/scutils/stats_collector.py
@@ -319,6 +319,12 @@ class ThreadedCounter(AbstractCounter):
         self.thread.setDaemon(True)
         self.thread.start()
 
+    def deactivate(self):
+        '''
+        Call to shut down the threaded stats collector without joining; returns immediately
+        '''
+        self.active = False
+
     def stop(self):
         '''
         Call to shut down the threaded stats collector


### PR DESCRIPTION
When stopping large numbers of ThreadedCounter objects in a loop, the `stop()` method serializes all of the thread joins, resulting in linear scaling of sleep time in the main loop. Adding a `deactivate()` method that shuts down the loop without joining allows us to collapse those sleep times and prevent excessive growth in shutdown delay.