### PR TITLE
Add python 3 support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # Python binaries
 *.pyc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
   - docker: 1
     dockerfile_name: Dockerfile.py2alpine
     docker_tag_suffix: dev-alpine
+  - docker: 1
+    dockerfile_name: Dockerfile.py3
+    docker_tag_suffix: dev-py3
 
 install: true
 

--- a/crawler/crawling/distributed_scheduler.py
+++ b/crawler/crawling/distributed_scheduler.py
@@ -282,7 +282,7 @@ class DistributedScheduler(object):
         try:
             obj = urllib.request.urlopen(settings.get('PUBLIC_IP_URL',
                                   'http://ip.42.pl/raw'))
-            results = self.ip_regex.findall(obj.read())
+            results = self.ip_regex.findall(obj.read().decode('utf-8'))
             if len(results) > 0:
                 self.my_ip = results[0]
             else:
@@ -313,7 +313,8 @@ class DistributedScheduler(object):
     def from_settings(cls, settings):
         server = redis.Redis(host=settings.get('REDIS_HOST'),
                              port=settings.get('REDIS_PORT'),
-                             db=settings.get('REDIS_DB'))
+                             db=settings.get('REDIS_DB'),
+                             decode_responses=True)
         persist = settings.get('SCHEDULER_PERSIST', True)
         up_int = settings.get('SCHEDULER_QUEUE_REFRESH', 10)
         hits = settings.get('QUEUE_HITS', 10)

--- a/crawler/crawling/log_retry_middleware.py
+++ b/crawler/crawling/log_retry_middleware.py
@@ -61,7 +61,8 @@ class LogRetryMiddleware(object):
         if self.settings['STATS_STATUS_CODES']:
             self.redis_conn = redis.Redis(host=self.settings.get('REDIS_HOST'),
                                           port=self.settings.get('REDIS_PORT'),
-                                          db=settings.get('REDIS_DB'))
+                                          db=settings.get('REDIS_DB'),
+                                          decode_responses=True)
 
             try:
                 self.redis_conn.info()

--- a/crawler/crawling/pipelines.py
+++ b/crawler/crawling/pipelines.py
@@ -111,7 +111,8 @@ class KafkaPipeline(object):
             producer = KafkaProducer(bootstrap_servers=settings['KAFKA_HOSTS'],
                                  retries=3,
                                  linger_ms=settings['KAFKA_PRODUCER_BATCH_LINGER_MS'],
-                                 buffer_memory=settings['KAFKA_PRODUCER_BUFFER_BYTES'])
+                                 buffer_memory=settings['KAFKA_PRODUCER_BUFFER_BYTES'],
+                                 value_serializer=lambda m: m.encode('utf-8'))
         except Exception as e:
                 logger.error("Unable to connect to Kafka in Pipeline"\
                     ", raising exit flag.")

--- a/crawler/crawling/redis_stats_middleware.py
+++ b/crawler/crawling/redis_stats_middleware.py
@@ -41,7 +41,8 @@ class RedisStatsMiddleware(object):
         # set up redis
         self.redis_conn = redis.Redis(host=settings.get('REDIS_HOST'),
             port=settings.get('REDIS_PORT'),
-            db=settings.get('REDIS_DB'))
+            db=settings.get('REDIS_DB'),
+            decode_responses=True)
 
         try:
             self.redis_conn.info()

--- a/crawler/tests/online.py
+++ b/crawler/tests/online.py
@@ -46,7 +46,8 @@ class TestLinkSpider(TestCase):
         # set up redis
         self.redis_conn = redis.Redis(host=self.settings['REDIS_HOST'],
                                       port=self.settings['REDIS_PORT'],
-                                      db=self.settings['REDIS_DB'])
+                                      db=self.settings['REDIS_DB'],
+                                      decode_responses=True)
         try:
             self.redis_conn.info()
         except ConnectionError:
@@ -66,7 +67,8 @@ class TestLinkSpider(TestCase):
             group_id="demo-id",
             auto_commit_interval_ms=10,
             consumer_timeout_ms=5000,
-            auto_offset_reset='earliest'
+            auto_offset_reset='earliest',
+            value_deserializer=lambda m: m.decode('utf-8')
         )
         time.sleep(1)
 

--- a/docker/crawler/Dockerfile.py3
+++ b/docker/crawler/Dockerfile.py3
@@ -1,0 +1,35 @@
+FROM python:3.6
+MAINTAINER Madison Bahmer <madison.bahmer@istresearch.com>
+
+# os setup
+RUN apt-get update && apt-get -y install \
+  python-lxml \
+  build-essential \
+  libssl-dev \
+  libffi-dev \
+  python-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# install requirements
+COPY utils /usr/src/utils
+COPY crawler/requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+RUN rm -rf /usr/src/utils
+
+# move codebase over
+COPY crawler /usr/src/app
+
+# override settings via localsettings.py
+COPY docker/crawler/settings.py /usr/src/app/crawling/localsettings.py
+
+# copy testing script into container
+COPY docker/run_docker_tests.sh /usr/src/app/run_docker_tests.sh
+
+# set up environment variables
+
+# run the spider
+CMD ["scrapy", "runspider", "crawling/spiders/link_spider.py"]

--- a/docker/kafka-monitor/Dockerfile.py3
+++ b/docker/kafka-monitor/Dockerfile.py3
@@ -1,0 +1,27 @@
+FROM python:3.6
+MAINTAINER Madison Bahmer <madison.bahmer@istresearch.com>
+
+# os setup
+RUN apt-get update
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# install requirements
+COPY utils /usr/src/utils
+COPY kafka-monitor/requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+RUN rm -rf /usr/src/utils
+
+# move codebase over
+COPY kafka-monitor /usr/src/app
+
+# override settings via localsettings.py
+COPY docker/kafka-monitor/settings.py /usr/src/app/localsettings.py
+
+# copy testing script into container
+COPY docker/run_docker_tests.sh /usr/src/app/run_docker_tests.sh
+
+# set up environment variables
+
+# run command
+CMD ["python", "kafka_monitor.py", "run"]

--- a/docker/redis-monitor/Dockerfile.py3
+++ b/docker/redis-monitor/Dockerfile.py3
@@ -1,0 +1,27 @@
+FROM python:3.6
+MAINTAINER Madison Bahmer <madison.bahmer@istresearch.com>
+
+# os setup
+RUN apt-get update
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# install requirements
+COPY utils /usr/src/utils
+COPY redis-monitor/requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+RUN rm -rf /usr/src/utils
+
+# move codebase over
+COPY redis-monitor /usr/src/app
+
+# override settings via localsettings.py
+COPY docker/redis-monitor/settings.py /usr/src/app/localsettings.py
+
+# copy testing script into container
+COPY docker/run_docker_tests.sh /usr/src/app/run_docker_tests.sh
+
+# set up environment variables
+
+# run command
+CMD ["python", "redis_monitor.py"]

--- a/docker/rest/Dockerfile.py3
+++ b/docker/rest/Dockerfile.py3
@@ -1,0 +1,27 @@
+FROM python:3.6
+MAINTAINER Madison Bahmer <madison.bahmer@istresearch.com>
+
+# os setup
+RUN apt-get update
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# install requirements
+COPY utils /usr/src/utils
+COPY rest/requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+RUN rm -rf /usr/src/utils
+
+# move codebase over
+COPY rest /usr/src/app
+
+# override settings via localsettings.py
+COPY docker/rest/settings.py /usr/src/app/localsettings.py
+
+# copy testing script into container
+COPY docker/run_docker_tests.sh /usr/src/app/run_docker_tests.sh
+
+# set up environment variables
+
+# run command
+CMD ["python", "rest_service.py"]

--- a/docker/run_docker_tests.sh
+++ b/docker/run_docker_tests.sh
@@ -13,8 +13,17 @@ if [ $? -eq 1 ]; then
     exit 1
 fi
 
-python tests/online.py -v
-if [ $? -eq 1 ]; then
-    echo "integration tests failed"
-    exit 1
+# if 3 parameters passed in, then it's util's test
+if [ $# -eq 3 ]; then
+    python tests/online.py -r $1 -p $2 -z $3
+    if [ $? -eq 1 ]; then
+        echo "integration tests failed"
+        exit 1
+    fi
+else
+    python tests/online.py -v
+    if [ $? -eq 1 ]; then
+        echo "integration tests failed"
+        exit 1
+    fi
 fi

--- a/docker/utils/Dockerfile
+++ b/docker/utils/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:2.7
+MAINTAINER Madison Bahmer <madison.bahmer@istresearch.com>
+
+# os setup
+RUN apt-get update
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# move codebase over and install requirements
+COPY utils /usr/src/app
+RUN pip install .
+RUN pip install nose
+
+# copy testing script into container
+COPY docker/run_docker_tests.sh /usr/src/app/run_docker_tests.sh
+
+# set up environment variables
+
+# run command
+CMD ["ping", "localhost"]

--- a/docker/utils/Dockerfile.py2alpine
+++ b/docker/utils/Dockerfile.py2alpine
@@ -1,0 +1,33 @@
+FROM python:2.7.12-alpine
+MAINTAINER Madison Bahmer <madison.bahmer@istresearch.com>
+
+# move codebase over
+WORKDIR /usr/src/app
+COPY utils /usr/src/app
+
+# Combine run command to create single intermeiate image layer
+# This MANDATORY because developments dependencies are huge.
+RUN mkdir -p /usr/src/app \
+ && cd /usr/src/app \
+# Installing runtime dependencies
+ && apk --no-cache add \
+      curl \
+# Installing buildtime dependencies. They will be removed at end of this
+# commands sequence.
+ && apk --no-cache add --virtual build-dependencies \
+      build-base \
+# Updating pip itself before installing packages
+ && pip install --no-cache-dir pip setuptools \
+# Installing scutils from local codebase
+ && pip install . \
+# Removing build dependencies leaving image layer clean and neat
+ && apk del build-dependencies
+RUN pip install nose
+
+# copy testing script into container
+COPY docker/run_docker_tests.sh /usr/src/app/run_docker_tests.sh
+
+# set up environment variables
+
+# run command
+CMD ["ping", "localhost"]

--- a/docker/utils/Dockerfile.py3
+++ b/docker/utils/Dockerfile.py3
@@ -1,0 +1,20 @@
+FROM python:3.6
+MAINTAINER Madison Bahmer <madison.bahmer@istresearch.com>
+
+# os setup
+RUN apt-get update
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# move codebase over and install requirements
+COPY utils /usr/src/app
+RUN pip install .
+RUN pip install nose
+
+# copy testing script into container
+COPY docker/run_docker_tests.sh /usr/src/app/run_docker_tests.sh
+
+# set up environment variables
+
+# run command
+CMD ["ping", "localhost"]

--- a/docs/topics/utils/redisqueue.rst
+++ b/docs/topics/utils/redisqueue.rst
@@ -123,7 +123,7 @@ You can use any of the three classes in the following way, you just need to have
     >>> import redis
     >>> import ujson
     >>> from scutils.redis_queue import RedisStack
-    >>> redis_conn = redis.Redis(host='scdev', port=6379)
+    >>> redis_conn = redis.Redis(host='scdev', port=6379, decode_responses=True)
     >>> queue = RedisStack(redis_conn, "stack_key", encoding=ujson))
     >>> queue.push('item1')
     >>> queue.push(['my', 'array', 'here'])

--- a/docs/topics/utils/redisqueue.rst
+++ b/docs/topics/utils/redisqueue.rst
@@ -141,46 +141,56 @@ In this example lets create a simple script that changes what type of Queue we u
 
 ::
 
+    import sys
     import redis
     from scutils.redis_queue import RedisStack, RedisQueue, RedisPriorityQueue
     import argparse
 
-    # change these for your Redis host
-    host = 'scdev'
-    port = 6379
-    redis_conn = redis.Redis(host=host, port=port)
 
-    parser = argparse.ArgumentParser(description='Example Redis Queues.')
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-q', '--queue', action='store_true', help="Use a RedisQueue")
-    group.add_argument('-s', '--stack', action='store_true',
-                           help="Use a RedisStack")
-    group.add_argument('-p', '--priority', action='store_true',
-                           help="Use a RedisPriorityQueue")
+    def main():
+        parser = argparse.ArgumentParser(description='Example Redis Queues.')
+        parser.add_argument('-r', '--redis-host', action='store', default='scdev',
+                            help="The Redis host ip")
+        parser.add_argument('-rp', '--redis-port', action='store', default='6379',
+                            help="The Redis port")
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('-q', '--queue', action='store_true', help="Use a RedisQueue")
+        group.add_argument('-s', '--stack', action='store_true',
+                            help="Use a RedisStack")
+        group.add_argument('-p', '--priority', action='store_true',
+                            help="Use a RedisPriorityQueue")
 
-    args = vars(parser.parse_args())
+        args = vars(parser.parse_args())
 
-    if args['queue']:
-        queue = RedisQueue(redis_conn, "my_key")
-    elif args['stack']:
-        queue = RedisStack(redis_conn, "my_key")
-    elif args['priority']:
-        queue = RedisPriorityQueue(redis_conn, "my_key")
+        host = args['redis_host']
+        port = args['redis_port']
+        redis_conn = redis.Redis(host=host, port=port, decode_responses=True)
 
-    print("Using " + queue.__class__.__name__)
+        if args['queue']:
+            queue = RedisQueue(redis_conn, "my_key")
+        elif args['stack']:
+            queue = RedisStack(redis_conn, "my_key")
+        elif args['priority']:
+            queue = RedisPriorityQueue(redis_conn, "my_key")
 
-    if isinstance(queue, RedisPriorityQueue):
-        queue.push("item1", 50)
-        queue.push("item2", 100)
-        queue.push("item3", 20)
-    else:
-        queue.push("item1")
-        queue.push("item2")
-        queue.push("item3")
+        print("Using " + queue.__class__.__name__)
 
-    print("Pop 1 " + queue.pop())
-    print("Pop 2 " + queue.pop())
-    print("Pop 3 " + queue.pop())
+        if isinstance(queue, RedisPriorityQueue):
+            queue.push("item1", 50)
+            queue.push("item2", 100)
+            queue.push("item3", 20)
+        else:
+            queue.push("item1")
+            queue.push("item2")
+            queue.push("item3")
+
+        print("Pop 1 " + queue.pop())
+        print("Pop 2 " + queue.pop())
+        print("Pop 3 " + queue.pop())
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
 
 Save the file as ``example_rq.py`` or use the one located at ``utils/examples/example_rq.py``, and now lets run the different tests.
 

--- a/docs/topics/utils/redisthrottledqueue.rst
+++ b/docs/topics/utils/redisthrottledqueue.rst
@@ -56,7 +56,7 @@ If you would like to throttle your Redis queue, you need to pass the queue in as
     >>> import redis
     >>> from scutils.redis_queue import RedisPriorityQueue
     >>> from scutils.redis_throttled_queue import RedisThrottledQueue
-    >>> redis_conn = redis.Redis(host='scdev', port=6379)
+    >>> redis_conn = redis.Redis(host='scdev', port=6379, decode_responses=True)
     >>> queue = RedisPriorityQueue(redis_conn, 'my_key')
     >>> t = RedisThrottledQueue(redis_conn, queue, 10, 5)
     >>> t.push('item', 5)
@@ -123,7 +123,7 @@ The Redis Throttled Queue really shines when multiple processes are trying to po
         queue = args['queue']
         elastic = args['elastic']
 
-        conn = redis.Redis(host=host, port=port)
+        conn = redis.Redis(host=host, port=port, decode_responses=True)
 
         q = RedisPriorityQueue(conn, queue)
         t = RedisThrottledQueue(conn, q, window, num, mod, elastic=elastic)

--- a/kafka-monitor/kafka_monitor.py
+++ b/kafka-monitor/kafka_monitor.py
@@ -123,7 +123,8 @@ class KafkaMonitor(object):
 
         redis_conn = redis.Redis(host=self.settings['REDIS_HOST'],
                                  port=self.settings['REDIS_PORT'],
-                                 db=self.settings.get('REDIS_DB'))
+                                 db=self.settings.get('REDIS_DB'),
+                                 decode_responses=True)
 
         try:
             redis_conn.info()
@@ -455,6 +456,7 @@ class KafkaMonitor(object):
                 self.settings['KAFKA_INCOMING_TOPIC'],
                 group_id=self.settings['KAFKA_GROUP'],
                 bootstrap_servers=brokers,
+                value_deserializer=lambda m: m.decode('utf-8'),
                 consumer_timeout_ms=self.settings['KAFKA_CONSUMER_TIMEOUT'],
                 auto_offset_reset=self.settings['KAFKA_CONSUMER_AUTO_OFFSET_RESET'],
                 auto_commit_interval_ms=self.settings['KAFKA_CONSUMER_COMMIT_INTERVAL_MS'],
@@ -478,7 +480,7 @@ class KafkaMonitor(object):
                                str(brokers))
 
             return KafkaProducer(bootstrap_servers=brokers,
-                                 value_serializer=lambda m: json.dumps(m),
+                                 value_serializer=lambda m: json.dumps(m).encode('utf-8'),
                                  retries=3,
                                  linger_ms=self.settings['KAFKA_PRODUCER_BATCH_LINGER_MS'],
                                  buffer_memory=self.settings['KAFKA_PRODUCER_BUFFER_BYTES'])

--- a/kafka-monitor/kafkadump.py
+++ b/kafka-monitor/kafkadump.py
@@ -102,6 +102,7 @@ def main():
                 topic,
                 group_id=consumer_id,
                 bootstrap_servers=kafka_host,
+                value_deserializer=lambda m: m.decode('utf-8'),
                 consumer_timeout_ms=settings['KAFKA_CONSUMER_TIMEOUT'],
                 auto_offset_reset=offset,
                 auto_commit_interval_ms=settings['KAFKA_CONSUMER_COMMIT_INTERVAL_MS'],

--- a/kafka-monitor/plugins/action_handler.py
+++ b/kafka-monitor/plugins/action_handler.py
@@ -17,7 +17,8 @@ class ActionHandler(BaseHandler):
         self.extract = tldextract.TLDExtract()
         self.redis_conn = redis.Redis(host=settings['REDIS_HOST'],
                                       port=settings['REDIS_PORT'],
-                                      db=settings.get('REDIS_DB'))
+                                      db=settings.get('REDIS_DB'),
+                                      decode_responses=True)
 
         try:
             self.redis_conn.info()

--- a/kafka-monitor/plugins/scraper_handler.py
+++ b/kafka-monitor/plugins/scraper_handler.py
@@ -18,7 +18,8 @@ class ScraperHandler(BaseHandler):
         self.extract = tldextract.TLDExtract()
         self.redis_conn = redis.Redis(host=settings['REDIS_HOST'],
                                       port=settings['REDIS_PORT'],
-                                      db=settings.get('REDIS_DB'))
+                                      db=settings.get('REDIS_DB'),
+                                      decode_responses=True)
 
         try:
             self.redis_conn.info()

--- a/kafka-monitor/plugins/stats_handler.py
+++ b/kafka-monitor/plugins/stats_handler.py
@@ -15,7 +15,8 @@ class StatsHandler(BaseHandler):
         '''
         self.redis_conn = redis.Redis(host=settings['REDIS_HOST'],
                                       port=settings['REDIS_PORT'],
-                                      db=settings.get('REDIS_DB'))
+                                      db=settings.get('REDIS_DB'),
+                                      decode_responses=True)
 
         try:
             self.redis_conn.info()

--- a/kafka-monitor/plugins/zookeeper_handler.py
+++ b/kafka-monitor/plugins/zookeeper_handler.py
@@ -18,7 +18,8 @@ class ZookeeperHandler(BaseHandler):
         self.extract = tldextract.TLDExtract()
         self.redis_conn = redis.Redis(host=settings['REDIS_HOST'],
                                       port=settings['REDIS_PORT'],
-                                      db=settings.get('REDIS_DB'))
+                                      db=settings.get('REDIS_DB'),
+                                      decode_responses=True)
 
         try:
             self.redis_conn.info()

--- a/kafka-monitor/tests/online.py
+++ b/kafka-monitor/tests/online.py
@@ -59,7 +59,8 @@ class TestKafkaMonitor(TestCase):
         self.redis_conn = redis.Redis(
             host=self.kafka_monitor.settings['REDIS_HOST'],
             port=self.kafka_monitor.settings['REDIS_PORT'],
-            db=self.kafka_monitor.settings['REDIS_DB'])
+            db=self.kafka_monitor.settings['REDIS_DB'],
+            decode_responses=True)
 
     def test_feed(self):
         json_req = "{\"uuid\":\"mytestid\"," \

--- a/redis-monitor/plugins/kafka_base_monitor.py
+++ b/redis-monitor/plugins/kafka_base_monitor.py
@@ -39,7 +39,7 @@ class KafkaBaseMonitor(BaseMonitor):
                                str(brokers))
 
             return KafkaProducer(bootstrap_servers=brokers,
-                                 value_serializer=lambda m: json.dumps(m),
+                                 value_serializer=lambda m: json.dumps(m).encode('utf-8'),
                                  retries=3,
                                  linger_ms=settings['KAFKA_PRODUCER_BATCH_LINGER_MS'],
                                  buffer_memory=settings['KAFKA_PRODUCER_BUFFER_BYTES'])

--- a/redis-monitor/plugins/zookeeper_monitor.py
+++ b/redis-monitor/plugins/zookeeper_monitor.py
@@ -56,6 +56,7 @@ class ZookeeperMonitor(KafkaBaseMonitor):
         data = None
         try:
             data = self.zoo_client.get(self.path)[0]
+            data = data.decode('utf-8')
         except ZookeeperError:
             e = "Unable to load Zookeeper config"
             self.logger.error(e)
@@ -92,7 +93,7 @@ class ZookeeperMonitor(KafkaBaseMonitor):
         # write the configuration back to zookeeper
         the_string = yaml.dump(the_dict, default_flow_style=False)
         try:
-            self.zoo_client.set(self.path, the_string)
+            self.zoo_client.set(self.path, the_string.encode('utf-8'))
         except ZookeeperError:
             e = "Unable to store Zookeeper config"
             self.logger.error(e)

--- a/redis-monitor/plugins/zookeeper_monitor.py
+++ b/redis-monitor/plugins/zookeeper_monitor.py
@@ -91,7 +91,7 @@ class ZookeeperMonitor(KafkaBaseMonitor):
             self.logger.warn("Unknown command given to Zookeeper Monitor")
 
         # write the configuration back to zookeeper
-        the_string = yaml.dump(the_dict, default_flow_style=False)
+        the_string = yaml.safe_dump(the_dict, default_flow_style=False)
         try:
             self.zoo_client.set(self.path, the_string.encode('utf-8'))
         except ZookeeperError:

--- a/redis-monitor/redis_monitor.py
+++ b/redis-monitor/redis_monitor.py
@@ -60,7 +60,13 @@ class RedisMonitor(object):
 
         self.redis_conn = redis.StrictRedis(host=self.settings['REDIS_HOST'],
                                       port=self.settings['REDIS_PORT'],
-                                      db=self.settings['REDIS_DB'])
+                                      db=self.settings['REDIS_DB'],
+                                      decode_responses=True)
+        # redis_lock needs a redis connection without setting decode_responses
+        # to True
+        self.lock_redis_conn = redis.StrictRedis(host=self.settings['REDIS_HOST'],
+                                                 port=self.settings['REDIS_PORT'],
+                                                 db=self.settings['REDIS_DB'])
 
         try:
             self.redis_conn.info()
@@ -182,7 +188,7 @@ class RedisMonitor(object):
         '''
         Returns a lock object, split for testing
         '''
-        return redis_lock.Lock(self.redis_conn, key,
+        return redis_lock.Lock(self.lock_redis_conn, key,
                                expire=self.settings['REDIS_LOCK_EXPIRATION'],
                                auto_renewal=True)
 

--- a/redis-monitor/tests/online.py
+++ b/redis-monitor/tests/online.py
@@ -61,6 +61,11 @@ class TestRedisMonitor(TestCase):
         self.redis_monitor.redis_conn = redis.Redis(
             host=self.redis_monitor.settings['REDIS_HOST'],
             port=self.redis_monitor.settings['REDIS_PORT'],
+            db=self.redis_monitor.settings['REDIS_DB'],
+            decode_responses=True)
+        self.redis_monitor.lock_redis_conn = redis.Redis(
+            host=self.redis_monitor.settings['REDIS_HOST'],
+            port=self.redis_monitor.settings['REDIS_PORT'],
             db=self.redis_monitor.settings['REDIS_DB'])
 
         self.redis_monitor._load_plugins()
@@ -72,7 +77,8 @@ class TestRedisMonitor(TestCase):
             group_id="demo-id",
             auto_commit_interval_ms=10,
             consumer_timeout_ms=5000,
-            auto_offset_reset='earliest'
+            auto_offset_reset='earliest',
+            value_deserializer=lambda m: m.decode('utf-8')
         )
         sleep(1)
 

--- a/redis-monitor/tests/test_plugins.py
+++ b/redis-monitor/tests/test_plugins.py
@@ -395,36 +395,36 @@ class TestZookeeperPlugin(TestCase, RegexFixer):
 
     def test_zk_handle_du(self):
         # domain update
-        s = 'blacklist: []\ndomains:\n  dmoz.org: {hits: 60, scale: 1.0, window: 60}\n'
+        s = b'blacklist: []\ndomains:\n  dmoz.org: {hits: 60, scale: 1.0, window: 60}\n'
         val = '{"uuid":"blah123","hits":15,"scale":0.9,"window":60}'
-        expected = 'blacklist: []\ndomains:\n  cnn.com:\n    hits: 15\n    scale: 0.9\n    window: 60\n  dmoz.org:\n    hits: 60\n    scale: 1.0\n    window: 60\n'
+        expected = b'blacklist: []\ndomains:\n  cnn.com:\n    hits: 15\n    scale: 0.9\n    window: 60\n  dmoz.org:\n    hits: 60\n    scale: 1.0\n    window: 60\n'
         self.plugin.zoo_client.get = MagicMock(return_value=(s,))
         self.plugin.handle(key="zk:domain-update:cnn.com:testapp", value=val)
         self.plugin.zoo_client.set.assert_called_once_with("/some/path", expected)
 
     def test_zk_handle_dr(self):
         # domain remove
-        s = 'blacklist: []\ndomains:\n  dmoz.org: {hits: 60, scale: 1.0, window: 60}\n'
+        s = b'blacklist: []\ndomains:\n  dmoz.org: {hits: 60, scale: 1.0, window: 60}\n'
         val = '{"uuid":"blah123"}'
-        expected = 'blacklist: []\ndomains: {}\n'
+        expected = b'blacklist: []\ndomains: {}\n'
         self.plugin.zoo_client.get = MagicMock(return_value=(s,))
         self.plugin.handle(key="zk:domain-remove:dmoz.org:testapp", value=val)
         self.plugin.zoo_client.set.assert_called_once_with("/some/path", expected)
 
     def test_zk_handle_bu(self):
         # blacklist update
-        s = 'blacklist: []\ndomains: {}\n'
+        s = b'blacklist: []\ndomains: {}\n'
         val = '{"uuid":"blah123"}'
-        expected = 'blacklist:\n- bingo.com\ndomains: {}\n'
+        expected = b'blacklist:\n- bingo.com\ndomains: {}\n'
         self.plugin.zoo_client.get = MagicMock(return_value=(s,))
         self.plugin.handle(key="zk:blacklist-update:bingo.com:testapp", value=val)
         self.plugin.zoo_client.set.assert_called_once_with("/some/path", expected)
 
     def test_zk_handle_br(self):
         # blacklist remove
-        s = 'blacklist: [bingo.com]\ndomains: {}\n'
+        s = b'blacklist: [bingo.com]\ndomains: {}\n'
         val = '{"uuid":"blah123"}'
-        expected = 'blacklist: []\ndomains: {}\n'
+        expected = b'blacklist: []\ndomains: {}\n'
         self.plugin.zoo_client.get = MagicMock(return_value=(s,))
         self.plugin.handle(key="zk:blacklist-remove:bingo.com:testapp", value=val)
         self.plugin.zoo_client.set.assert_called_once_with("/some/path", expected)

--- a/rest/rest_service.py
+++ b/rest/rest_service.py
@@ -63,7 +63,7 @@ def error_catch(f):
                                                    True,
                                                    instance.UNKNOWN_ERROR)
             log_dict = deepcopy(ret_dict)
-            log_dict['error']['cause'] = e.message
+            log_dict['error']['cause'] = ""
             log_dict['error']['exception'] = str(e)
             log_dict['error']['ex'] = traceback.format_exc()
             instance.logger.error("Uncaught Exception Thrown", log_dict)
@@ -102,7 +102,7 @@ def validate_schema(schema_name):
             instance = args[0]
             try:
                 instance.validator(instance.schemas[schema_name]).validate(request.get_json())
-            except ValidationError, e:
+            except ValidationError as e:
                 ret_dict = instance._create_ret_object(instance.FAILURE,
                                                        None, True,
                                                        instance.BAD_SCHEMA,
@@ -352,7 +352,8 @@ class RestService(object):
                                   str(self.settings['REDIS_HOST']))
                 self.redis_conn = redis.StrictRedis(host=self.settings['REDIS_HOST'],
                                               port=self.settings['REDIS_PORT'],
-                                              db=self.settings['REDIS_DB'])
+                                              db=self.settings['REDIS_DB'],
+                                              decode_responses=True)
                 self.redis_conn.info()
                 self.redis_connected = True
                 self.logger.info("Successfully connected to redis")

--- a/rest/tests/test_rest_service.py
+++ b/rest/tests/test_rest_service.py
@@ -10,6 +10,7 @@ from rest_service import (log_call, error_catch, validate_json,
 import mock
 import json
 import flask
+import six
 
 from kafka.common import OffsetOutOfRangeError
 from kafka.conn import ConnectionStates
@@ -51,13 +52,13 @@ class TestRestService(TestCase):
         self.rest_service.logger = MagicMock()
 
     @mock.patch('os.listdir', MagicMock(return_value=['hey.json']))
-    @mock.patch('__builtin__.open', mock_open(read_data='bibble'), create=True)
+    @mock.patch('six.moves.builtins.open', mock_open(read_data='bibble'), create=True)
     def test_load_schemas_bad(self):
         with self.assertRaises(ValueError):
             self.rest_service._load_schemas()
 
     @mock.patch('os.listdir', MagicMock(return_value=['hey2.json']))
-    @mock.patch('__builtin__.open', mock_open(read_data='{\"stuff\":\"value\"}'), create=True)
+    @mock.patch('six.moves.builtins.open', mock_open(read_data='{\"stuff\":\"value\"}'), create=True)
     def test_load_schemas_bad(self):
         self.rest_service._load_schemas()
         self.assertEquals(self.rest_service.schemas,
@@ -475,7 +476,7 @@ class TestRestService(TestCase):
             self.assertEquals(results, 'data')
 
         # invalid schema
-        data = '{"otherkey": "bad data"}'
+        data = u'{"value": "data here", "otherkey": "bad data"}'
         with self.rest_service.app.test_request_context(data=data,
                                                         content_type='application/json'):
             results = override.test_schema()
@@ -483,11 +484,15 @@ class TestRestService(TestCase):
             self.assertEquals(override.logger.error.call_args[0][0],
                               "Invalid Schema")
 
+            if six.PY3:
+                cause_text = u"Additional properties are not allowed ('otherkey' was unexpected)"
+            else:
+                cause_text = u"Additional properties are not allowed (u'otherkey' was unexpected)"
             d = {
                 u'data': None,
                 u'error': {
                     u'message': u"JSON did not validate against schema.",
-                    u'cause': u"Additional properties are not allowed (u'otherkey' was unexpected)"
+                    u'cause': cause_text
                 },
                 u'status': u'FAILURE'
             }
@@ -587,7 +592,7 @@ class TestRestService(TestCase):
             data = json.loads(results[0].data)
             self.assertEquals(data, d)
             self.assertEquals(results[1], 200)
-            self.assertFalse(self.rest_service.uuids.has_key('key'))
+            self.assertFalse('key' in self.rest_service.uuids)
 
         # test with uuid, no response
         time_list = [0, 1, 2, 3, 4, 5, 6]
@@ -606,7 +611,7 @@ class TestRestService(TestCase):
             data = json.loads(results[0].data)
             self.assertEquals(data, d)
             self.assertEquals(results[1], 200)
-            self.assertTrue(self.rest_service.uuids.has_key('key'))
+            self.assertTrue('key' in self.rest_service.uuids)
             self.assertEquals(self.rest_service.uuids['key'], 'poll')
 
     def test_poll(self):

--- a/run_online_tests.sh
+++ b/run_online_tests.sh
@@ -6,20 +6,22 @@
 
 HOST='localhost'
 PORT=6379
+ZOOKEEPER_HOST='localhost:2181'
 
-if [ $# -ne 2 ]
+if [ $# -ne 3 ]
   then
-    echo "---- Running utils online test with localhost 6379"
+    echo "---- Running utils online test with redis on localhost:6379 and zookeeper on localhost:2181"
     echo "Other usage:"
-    echo "    ./bundle.sh <utils_redis_host> <utils_redis_port>"
+    echo "    ./bundle.sh <utils_redis_host> <utils_redis_port> <utils_zookeeper_host>"
 else
-    echo "---- Using custom redis host and port for utils online test"
+    echo "---- Using custom redis and zookeeper host and port for utils online test"
     HOST=$1
     PORT=$2
+    ZOOKEEPER_HOST=$3
 fi
 
 cd utils
-python tests/online.py -r $HOST -p $PORT
+python tests/online.py -r $HOST -p $PORT -z $ZOOKEEPER_HOST
 if [ $? -eq 1 ]; then
     echo "utils tests failed"
     exit 1

--- a/travis/ansible.sh
+++ b/travis/ansible.sh
@@ -19,6 +19,9 @@ sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm /bin/bash -c "ans
 # Install coveralls and other pip requiremnts
 sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm /bin/bash -c "virtualenv ${PWD}/sc; source ${PWD}/sc/bin/activate; cd ${PWD}; pip install -r requirements.txt; find . -name "*.pyc" -type f -delete;"
 
+# Install scutils from source
+sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm /bin/bash -c "virtualenv ${PWD}/sc; source ${PWD}/sc/bin/activate; cd ${PWD}; pip uninstall scutils -y; cd utils; python setup.py install; cd ../; find . -name "*.pyc" -type f -delete;"
+
 # Run offline tests
 sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm /bin/bash -c "source ${PWD}/sc/bin/activate; cd ${PWD}; ./run_offline_tests.sh"
 

--- a/travis/docker-compose.test.yml
+++ b/travis/docker-compose.test.yml
@@ -2,6 +2,12 @@ version: '2'
 # this file is used for travis ci testing, and is built in .travis.yml
 
 services:
+  utils:
+    image: istresearch/scrapy-cluster:utils-test
+    depends_on:
+      - kafka
+      - redis
+      - zookeeper
   kafka_monitor:
     image: istresearch/scrapy-cluster:kafka-monitor-test
     depends_on:

--- a/travis/docker.sh
+++ b/travis/docker.sh
@@ -3,6 +3,7 @@
 set -e
 
 # Build Dockerfiles for Scrapy Cluster
+sudo docker build --rm=true --file docker/utils/$dockerfile_name --tag=istresearch/scrapy-cluster:utils-test .
 sudo docker build --rm=true --file docker/kafka-monitor/$dockerfile_name --tag=istresearch/scrapy-cluster:kafka-monitor-test .
 sudo docker build --rm=true --file docker/redis-monitor/$dockerfile_name --tag=istresearch/scrapy-cluster:redis-monitor-test .
 sudo docker build --rm=true --file docker/crawler/$dockerfile_name --tag=istresearch/scrapy-cluster:crawler-test .
@@ -15,6 +16,7 @@ sudo docker-compose -f travis/docker-compose.test.yml up -d
 sleep 10
 
 # run docker unit and integration tests for each component
+sudo docker-compose -f travis/docker-compose.test.yml exec utils ./run_docker_tests.sh redis 6379 zookeeper:2181
 sudo docker-compose -f travis/docker-compose.test.yml exec kafka_monitor ./run_docker_tests.sh
 sudo docker-compose -f travis/docker-compose.test.yml exec redis_monitor ./run_docker_tests.sh
 sudo docker-compose -f travis/docker-compose.test.yml exec crawler ./run_docker_tests.sh
@@ -33,6 +35,7 @@ if [ "$TRAVIS_BRANCH" = "dev" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$T
     sudo docker build --rm=true --file docker/rest/$dockerfile_name --tag=istresearch/scrapy-cluster:rest-$docker_tag_suffix .
 
     # remove 'test' images
+    sudo docker rmi istresearch/scrapy-cluster:utils-test
     sudo docker rmi istresearch/scrapy-cluster:kafka-monitor-test
     sudo docker rmi istresearch/scrapy-cluster:redis-monitor-test
     sudo docker rmi istresearch/scrapy-cluster:crawler-test

--- a/utils/examples/example_rq.py
+++ b/utils/examples/example_rq.py
@@ -1,40 +1,50 @@
+import sys
 import redis
 from scutils.redis_queue import RedisStack, RedisQueue, RedisPriorityQueue
 import argparse
 
-# change these for your Redis host
-host = 'scdev'
-port = 6379
-redis_conn = redis.Redis(host=host, port=port, decode_responses=True)
 
-parser = argparse.ArgumentParser(description='Example Redis Queues.')
-group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument('-q', '--queue', action='store_true', help="Use a RedisQueue")
-group.add_argument('-s', '--stack', action='store_true',
-                       help="Use a RedisStack")
-group.add_argument('-p', '--priority', action='store_true',
-                       help="Use a RedisPriorityQueue")
+def main():
+    parser = argparse.ArgumentParser(description='Example Redis Queues.')
+    parser.add_argument('-r', '--redis-host', action='store', default='scdev',
+                        help="The Redis host ip")
+    parser.add_argument('-rp', '--redis-port', action='store', default='6379',
+                        help="The Redis port")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-q', '--queue', action='store_true', help="Use a RedisQueue")
+    group.add_argument('-s', '--stack', action='store_true',
+                        help="Use a RedisStack")
+    group.add_argument('-p', '--priority', action='store_true',
+                        help="Use a RedisPriorityQueue")
 
-args = vars(parser.parse_args())
+    args = vars(parser.parse_args())
 
-if args['queue']:
-    queue = RedisQueue(redis_conn, "my_key")
-elif args['stack']:
-    queue = RedisStack(redis_conn, "my_key")
-elif args['priority']:
-    queue = RedisPriorityQueue(redis_conn, "my_key")
+    host = args['redis_host']
+    port = args['redis_port']
+    redis_conn = redis.Redis(host=host, port=port, decode_responses=True)
 
-print("Using " + queue.__class__.__name__)
+    if args['queue']:
+        queue = RedisQueue(redis_conn, "my_key")
+    elif args['stack']:
+        queue = RedisStack(redis_conn, "my_key")
+    elif args['priority']:
+        queue = RedisPriorityQueue(redis_conn, "my_key")
 
-if isinstance(queue, RedisPriorityQueue):
-    queue.push("item1", 50)
-    queue.push("item2", 100)
-    queue.push("item3", 20)
-else:
-    queue.push("item1")
-    queue.push("item2")
-    queue.push("item3")
+    print("Using " + queue.__class__.__name__)
 
-print("Pop 1 " + queue.pop())
-print("Pop 2 " + queue.pop())
-print("Pop 3 " + queue.pop())
+    if isinstance(queue, RedisPriorityQueue):
+        queue.push("item1", 50)
+        queue.push("item2", 100)
+        queue.push("item3", 20)
+    else:
+        queue.push("item1")
+        queue.push("item2")
+        queue.push("item3")
+
+    print("Pop 1 " + queue.pop())
+    print("Pop 2 " + queue.pop())
+    print("Pop 3 " + queue.pop())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/examples/example_rq.py
+++ b/utils/examples/example_rq.py
@@ -5,7 +5,7 @@ import argparse
 # change these for your Redis host
 host = 'scdev'
 port = 6379
-redis_conn = redis.Redis(host=host, port=port)
+redis_conn = redis.Redis(host=host, port=port, decode_responses=True)
 
 parser = argparse.ArgumentParser(description='Example Redis Queues.')
 group = parser.add_mutually_exclusive_group(required=True)

--- a/utils/examples/example_rtq.py
+++ b/utils/examples/example_rtq.py
@@ -44,7 +44,7 @@ def main():
     queue = args['queue']
     elastic = args['elastic']
 
-    conn = redis.Redis(host=host, port=port)
+    conn = redis.Redis(host=host, port=port, decode_responses=True)
 
     q = RedisPriorityQueue(conn, queue)
     t = RedisThrottledQueue(conn, q, window, num, mod, elastic=elastic)

--- a/utils/scutils/redis_queue.py
+++ b/utils/scutils/redis_queue.py
@@ -39,7 +39,7 @@ class Base(object):
         @requires: The object be serializable
         '''
         if self.encoding.__name__ == 'pickle':
-            return self.encoding.dumps(item, protocol=-1)
+            return self.encoding.dumps(item, protocol=-1).decode('latin1')
         else:
             return self.encoding.dumps(item)
 
@@ -47,7 +47,10 @@ class Base(object):
         '''
         Decode an item previously encoded
         '''
-        return self.encoding.loads(encoded_item)
+        if self.encoding.__name__ == 'pickle':
+            return self.encoding.loads(encoded_item.encode('latin1'))
+        else:
+            return self.encoding.loads(encoded_item)
 
     def __len__(self):
         '''

--- a/utils/scutils/stats_collector.py
+++ b/utils/scutils/stats_collector.py
@@ -209,7 +209,8 @@ class AbstractCounter(object):
         '''
         if redis_conn is None:
             if host is not None and port is not None:
-                self.redis_conn = redis.Redis(host=host, port=port)
+                self.redis_conn = redis.Redis(host=host, port=port,
+                                              decode_responses=True)
             else:
                 raise Exception("Please specify some form of connection "
                                     "to Redis")

--- a/utils/scutils/zookeeper_watcher.py
+++ b/utils/scutils/zookeeper_watcher.py
@@ -202,6 +202,7 @@ class ZookeeperWatcher(object):
         try:
             # grab the file
             result, stat = self.zoo_client.get(path, watch=self.watch_file)
+            result = result.decode('utf-8')
         except ZookeeperError:
             self.set_valid(False)
             self.call_error(self.INVALID_GET)
@@ -243,6 +244,7 @@ class ZookeeperWatcher(object):
             try:
                 conf_string, stat2 = self.zoo_client.get(self.point_path,
                                                     watch=self.watch_pointed)
+                conf_string = conf_string.decode('utf-8')
             except ZookeeperError:
                 self.old_data = ''
                 self.set_valid(False)

--- a/utils/tests/online.py
+++ b/utils/tests/online.py
@@ -10,7 +10,6 @@ from unittest import TestCase
 from mock import MagicMock
 import time
 import sys
-import six
 
 import redis
 import argparse
@@ -129,7 +128,7 @@ class TestStatsThreaded(RedisMixin, TestCase):
         self.redis_conn.set('default_counter:2015-10', 'stuff2')
 
         tc.purge_old()
-        self.assertEqual([six.b('default_counter:2015-10')],
+        self.assertEqual(['default_counter:2015-10'],
                          self.redis_conn.keys(tc.get_key() + ':*'))
 
         self.redis_conn.delete('default_counter:2015-10')
@@ -377,7 +376,8 @@ if __name__ == '__main__':
                         help="The Redis port")
 
     args = vars(parser.parse_args())
-    redis_conn = redis.Redis(host=args['redis_host'], port=args['redis_port'])
+    redis_conn = redis.Redis(host=args['redis_host'], port=args['redis_port'],
+                             decode_responses=True)
 
     # build testing suite
     suite = unittest.TestSuite()

--- a/utils/tests/online.py
+++ b/utils/tests/online.py
@@ -13,6 +13,7 @@ import sys
 
 import redis
 import argparse
+from kazoo.client import KazooClient
 
 from scutils.redis_queue import RedisQueue, RedisPriorityQueue, RedisStack
 
@@ -366,6 +367,20 @@ class TestStatsBitMapCounter(RedisMixin, TestCase, CleanMixin):
         self.assertEqual(1, counter.value())
         counter.stop()
         self.clean_keys(counter.key)
+
+
+class TestZookeeperWatcher(TestCase):
+    def __init__(self, hosts):
+        self.hosts = hosts
+
+    def setUp(self):
+        self.zoo_client = KazooClient(hosts=self.hosts)
+        self.zoo_client.start()
+
+    def tearDown(self):
+        self.zoo_client.stop()
+        self.zoo_client.close()
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Online deployment Test"

--- a/utils/tests/test_redis_queue.py
+++ b/utils/tests/test_redis_queue.py
@@ -29,14 +29,14 @@ class TestBase(TestCase):
     def test_encode(self):
         q = Base(MagicMock(), 'key', pickle)
         # python pickling is different between versions
-        data = pickle.dumps('cool', protocol=-1)
+        data = pickle.dumps('cool', protocol=-1).decode('latin1')
         self.assertEquals(q._encode_item('cool'), data)
         q2 = Base(MagicMock(), 'key', ujson)
         self.assertEquals(q2._encode_item('cool2'), '"cool2"')
 
     def test_decode(self):
         q = Base(MagicMock(), 'key', pickle)
-        self.assertEquals(q._decode_item(b"\x80\x02U\x04coolq\x00."), 'cool')
+        self.assertEquals(q._decode_item(u"\x80\x02U\x04coolq\x00."), 'cool')
 
         q2 = Base(MagicMock(), 'key', ujson)
         self.assertEquals(q2._decode_item('"cool2"'), 'cool2')

--- a/utils/tests/test_zookeeper_watcher.py
+++ b/utils/tests/test_zookeeper_watcher.py
@@ -9,7 +9,7 @@ class TestZookeeperWatcher(TestCase):
     def setUp(self):
 
         zoo_client = MagicMock()
-        zoo_client.get = MagicMock(return_value=('data', 'blah'))
+        zoo_client.get = MagicMock(return_value=(b'data', 'blah'))
 
         with patch('scutils.zookeeper_watcher.KazooClient') as k:
             k.return_value = zoo_client

--- a/utils/tests/throttled_queue.py
+++ b/utils/tests/throttled_queue.py
@@ -44,7 +44,7 @@ def main():
     mod = args['moderate']
     queue = args['queue']
 
-    conn = redis.Redis(host=host, port=port)
+    conn = redis.Redis(host=host, port=port, decode_responses=True)
 
     q = RedisPriorityQueue(conn, queue)
     t = RedisThrottledQueue(conn, q, window, num, mod)


### PR DESCRIPTION
Use **decode_responses** option on Redis client and **value_deserializer**,**value_serializer** option on Kafka client to handle unicode problem. Also fix several syntax error and update several test cases for python 3. And as scrapy-cluster 1.2 use ujson instead of pickle, I think no migration is needed.