### PR TITLE
Improve request serialization handling in scheduler

### DIFF
--- a/crawler/crawling/distributed_scheduler.py
+++ b/crawler/crawling/distributed_scheduler.py
@@ -487,8 +487,7 @@ class DistributedScheduler(object):
                 # item is a serialized request
                 req = request_from_dict(item)
             else:
-                # item is feeded from outside and is not a serialized request,
-                # parse it manually
+                # item is a feed from outside, parse it manually
                 req = self.request_from_feed(item)
 
             # extra check to add items to request

--- a/crawler/crawling/distributed_scheduler.py
+++ b/crawler/crawling/distributed_scheduler.py
@@ -485,7 +485,7 @@ class DistributedScheduler(object):
                     .format(url=item['url']))
             if 'meta' in item:
                 # item is a serialized request
-                req = request_from_dict(item)
+                req = request_from_dict(item, self.spider)
             else:
                 # item is a feed from outside, parse it manually
                 req = self.request_from_feed(item)

--- a/crawler/crawling/distributed_scheduler.py
+++ b/crawler/crawling/distributed_scheduler.py
@@ -7,6 +7,7 @@ from builtins import object
 from scrapy.http import Request
 from scrapy.conf import settings
 from scrapy.utils.python import to_unicode
+from scrapy.utils.reqser import request_to_dict, request_from_dict
 
 import redis
 import random
@@ -391,7 +392,7 @@ class DistributedScheduler(object):
         if not request.dont_filter and self.dupefilter.request_seen(request):
             self.logger.debug("Request not added back to redis")
             return
-        req_dict = self.request_to_dict(request)
+        req_dict = request_to_dict(request, self.spider)
 
         if not self.is_blacklisted(req_dict['meta']['appid'],
                                    req_dict['meta']['crawlid']):
@@ -435,28 +436,6 @@ class DistributedScheduler(object):
             self.logger.debug("Crawlid: '{id}' Appid: '{appid}' blacklisted"
                               .format(appid=req_dict['meta']['appid'],
                                       id=req_dict['meta']['crawlid']))
-
-    def request_to_dict(self, request):
-        '''
-        Convert Request object to a dict.
-        modified from scrapy.utils.reqser
-        '''
-        req_dict = {
-            # urls should be safe (safe_string_url)
-            'url': to_unicode(request.url),
-            'method': request.method,
-            'headers': dict(request.headers),
-            'body': request.body,
-            'cookies': request.cookies,
-            'meta': request.meta,
-            '_encoding': request._encoding,
-            'priority': request.priority,
-            'dont_filter': request.dont_filter,
-             #  callback/errback are assumed to be a bound instance of the spider
-            'callback': None if request.callback is None else request.callback.__name__,
-            'errback': None if request.errback is None else request.errback.__name__,
-        }
-        return req_dict
 
     def find_item(self):
         '''
@@ -504,49 +483,46 @@ class DistributedScheduler(object):
         if item:
             self.logger.debug(u"Found url to crawl {url}" \
                     .format(url=item['url']))
-            try:
-                req = Request(item['url'])
-            except ValueError:
-                # need absolute url
-                # need better url validation here
-                req = Request('http://' + item['url'])
-
-            try:
-                if 'callback' in item and item['callback'] is not None:
-                    req.callback = getattr(self.spider, item['callback'])
-            except AttributeError:
-                self.logger.warn("Unable to find callback method")
-
-            try:
-                if 'errback' in item and item['errback'] is not None:
-                    req.errback = getattr(self.spider, item['errback'])
-            except AttributeError:
-                self.logger.warn("Unable to find errback method")
-
             if 'meta' in item:
-                item = item['meta']
-
-            # defaults not in schema
-            if 'curdepth' not in item:
-                item['curdepth'] = 0
-            if "retry_times" not in item:
-                item['retry_times'] = 0
-
-            for key in list(item.keys()):
-                req.meta[key] = item[key]
+                # item is a serialized request
+                req = request_from_dict(item)
+            else:
+                # item is feeded from outside and is not a serialized request,
+                # parse it manually
+                req = self.request_from_feed(item)
 
             # extra check to add items to request
-            if 'useragent' in item and item['useragent'] is not None:
-                req.headers['User-Agent'] = item['useragent']
-            if 'cookie' in item and item['cookie'] is not None:
-                if isinstance(item['cookie'], dict):
-                    req.cookies = item['cookie']
-                elif isinstance(item['cookie'], basestring):
-                    req.cookies = self.parse_cookie(item['cookie'])
+            if 'useragent' in req.meta and req.meta['useragent'] is not None:
+                req.headers['User-Agent'] = req.meta['useragent']
 
             return req
 
         return None
+
+    def request_from_feed(self, item):
+        try:
+            req = Request(item['url'])
+        except ValueError:
+            # need absolute url
+            # need better url validation here
+            req = Request('http://' + item['url'])
+
+        # defaults not in schema
+        if 'curdepth' not in item:
+            item['curdepth'] = 0
+        if "retry_times" not in item:
+            item['retry_times'] = 0
+
+        for key in list(item.keys()):
+            req.meta[key] = item[key]
+
+        # extra check to add items to request
+        if 'cookie' in item and item['cookie'] is not None:
+            if isinstance(item['cookie'], dict):
+                req.cookies = item['cookie']
+            elif isinstance(item['cookie'], basestring):
+                req.cookies = self.parse_cookie(item['cookie'])
+        return req
 
     def parse_cookie(self, string):
         '''

--- a/crawler/requirements.txt
+++ b/crawler/requirements.txt
@@ -1,40 +1,40 @@
-attrs==16.3.0 # Updated from 16.1.0
-cffi==1.9.1 # Updated from 1.7.0
+attrs==17.2.0 # Updated from 16.3.0
+cffi==1.10.0 # Updated from 1.9.1
 ConcurrentLogHandler==0.9.1
-cryptography==1.8.1 # Updated from 1.5
-cssselect==1.0.1 # Updated from 0.9.2
+cryptography==2.0.3 # Updated from 1.8.1
+cssselect==1.0.1
 enum34==1.1.6
 funcsigs==1.0.2
-future==0.16.0 # Updated from 0.15.2
-idna==2.5 # Updated from 2.1
-ipaddress==1.0.18 # Updated from 1.0.16
-kafka-python==1.3.3 # Updated from 1.3.2
-kazoo==2.2.1
-lxml==3.7.3 # Updated from 3.6.4
+future==0.16.0
+idna==2.6 # Updated from 2.5
+ipaddress==1.0.18
+kafka-python==1.3.4 # Updated from 1.3.3
+kazoo==2.4.0 # Updated from 2.2.1
+lxml==3.8.0 # Updated from 3.7.3
 mock==2.0.0
 nose==1.3.7
-parsel==1.1.0 # Updated from 1.0.3
-pbr==2.0.0 # Updated from 1.10.0
-pyasn1==0.2.3 # Updated from 0.1.9
-pyasn1-modules==0.0.8
-pycparser==2.17 # Updated from 2.14
+parsel==1.2.0 # Updated from 1.1.0
+pbr==3.1.1 # Updated from 2.0.0
+pyasn1==0.3.2 # Updated from 0.2.3
+pyasn1-modules==0.0.11 # Updated from 0.0.8
+pycparser==2.18 # Updated from 2.17
 PyDispatcher==2.0.5
-pyOpenSSL==16.2.0 # Updated from 16.1.0
-python-json-logger==0.1.7 # Updated from 0.1.5
+pyOpenSSL==17.2.0 # Updated from 16.2.0
+python-json-logger==0.1.8 # Updated from 0.1.7
 PyYAML==3.12
 queuelib==1.4.2
 redis==2.10.5
-requests==2.13.0 # Updated from 2.11.1
-requests-file==1.4.1 # Updated from 1.4
+requests==2.18.3 # Updated from 2.13.0
+requests-file==1.4.2 # Updated from 1.4.1
 retrying==1.3.3
-Scrapy==1.3.3
+Scrapy==1.4.0 # Updated from 1.3.3
 ../utils # scutils==1.3.0dev0
-service-identity==16.0.0
+service-identity==17.0.0 # Updated from 16.0.0
 six==1.10.0
-testfixtures==4.13.5 # Updated from 4.10.0
-tldextract==2.0.2 # Updated from 2.0.1
-Twisted==17.1.0 # Updated from 16.4.0
+testfixtures==5.1.1 # Updated from 4.13.5
+tldextract==2.1.0 # Updated from 2.0.2
+Twisted==17.5.0 # Updated from 17.1.0
 ujson==1.35
-w3lib==1.17.0 # Updated from 1.16.0
-zope.interface==4.3.3 # Updated from 4.2.0
+w3lib==1.18.0 # Updated from 1.17.0
+zope.interface==4.4.2 # Updated from 4.3.3
 # Generated with piprot 0.9.7


### PR DESCRIPTION
Use scrapy's **request_to_dict**,**request_from_dict** to serialize requests so we can handle post request with parameters in request body.