### PR TITLE
Fix assert deprecations

### DIFF
--- a/crawler/tests/online.py
+++ b/crawler/tests/online.py
@@ -101,7 +101,7 @@ class TestLinkSpider(TestCase):
                     and the_dict['crawlid'] == 'abc12345':
                 message_count += 1
 
-        self.assertEquals(message_count, 1)
+        self.assertEqual(message_count, 1)
 
     def tearDown(self):
         keys = self.redis_conn.keys('stats:crawler:*:test-spider:*')

--- a/crawler/tests/test_distributed_scheduler.py
+++ b/crawler/tests/test_distributed_scheduler.py
@@ -60,7 +60,7 @@ class TestDistributedSchedulerEnqueueRequest(ThrottleMixin, TestCase):
 
         # test request already seen
         self.scheduler.dupefilter.request_seen = MagicMock(return_value=True)
-        self.assertEquals(self.scheduler.enqueue_request(self.req), None)
+        self.assertEqual(self.scheduler.enqueue_request(self.req), None)
 
         # test request not expiring and queue seen
         self.scheduler.queue_keys = ['link:ex.com:queue']
@@ -150,7 +150,7 @@ class TestDistributedSchedulerRequestFromFeed(ThrottleMixin, TestCase):
             "spiderid": "link",
         }
         out = self.scheduler.request_from_feed(feed)
-        self.assertEquals(out.url, 'http://ex.com')
+        self.assertEqual(out.url, 'http://ex.com')
         for key in out.meta:
             self.assertEqual(out.meta[key], self.req.meta[key])
 
@@ -194,7 +194,7 @@ class TestDistributedSchedulerNextRequest(ThrottleMixin, TestCase):
         }
         self.scheduler.find_item = MagicMock(return_value=feed)
         out = self.scheduler.next_request()
-        self.assertEquals(out.url, 'http://ex.com')
+        self.assertEqual(out.url, 'http://ex.com')
         for key in out.meta:
             self.assertEqual(out.meta[key], self.req.meta[key])
 
@@ -206,13 +206,13 @@ class TestDistributedSchedulerNextRequest(ThrottleMixin, TestCase):
         exist_item["meta"]["spiderid"] = "link"
         self.scheduler.find_item = MagicMock(return_value=exist_item)
         out = self.scheduler.next_request()
-        self.assertEquals(out.url, 'http://ex.com')
+        self.assertEqual(out.url, 'http://ex.com')
         for key in out.meta:
             self.assertEqual(out.meta[key], self.req.meta[key])
 
         # test didn't get item
         self.scheduler.find_item = MagicMock(return_value=None)
-        self.assertEquals(self.scheduler.next_request(), None)
+        self.assertEqual(self.scheduler.next_request(), None)
 
 
 class TestDistributedSchedulerChangeConfig(ThrottleMixin, TestCase):

--- a/crawler/tests/test_log_retry_middleware.py
+++ b/crawler/tests/test_log_retry_middleware.py
@@ -26,7 +26,7 @@ class TestLogRetryMiddlewareStats(TestCase):
 
         # test nothing
         self.lrm._setup_stats_status_codes()
-        self.assertEquals([str(x) for x in self.lrm.stats_dict.keys()], ['lifetime'])
+        self.assertEqual([str(x) for x in self.lrm.stats_dict.keys()], ['lifetime'])
 
         # test good/bad rolling stats
         self.lrm.stats_dict = {}
@@ -43,7 +43,7 @@ class TestLogRetryMiddlewareStats(TestCase):
 
         # check that both keys are set up
         self.lrm._setup_stats_status_codes()
-        self.assertEquals(
+        self.assertEqual(
             sorted([str(x) for x in self.lrm.stats_dict.keys()]),
             sorted(good))
 
@@ -51,12 +51,12 @@ class TestLogRetryMiddlewareStats(TestCase):
 
         for time_key in self.lrm.stats_dict:
             if time_key == 0:
-                self.assertEquals(
+                self.assertEqual(
                     self.lrm.stats_dict[0].key,
                     '{k}:lifetime'.format(k=k1)
                     )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     self.lrm.stats_dict[time_key].key,
                     '{k}:{t}'.format(k=k1, t=time_key)
                     )

--- a/crawler/tests/test_meta_passthrough_middleware.py
+++ b/crawler/tests/test_meta_passthrough_middleware.py
@@ -33,13 +33,13 @@ class TestMetaPassthroughMiddleware(TestCase):
 
         for item in self.mpm.process_spider_output(a, test_list, MagicMock()):
             if isinstance(item, Request):
-                self.assertEquals(a.meta, item.meta)
+                self.assertEqual(a.meta, item.meta)
             yield_count += 1
 
-        self.assertEquals(yield_count, 3)
+        self.assertEqual(yield_count, 3)
 
         # 1 debug for the method, 1 debug for the request
-        self.assertEquals(self.mpm.logger.debug.call_count, 2)
+        self.assertEqual(self.mpm.logger.debug.call_count, 2)
 
         # test meta unchanged if already exists
         r = Request('http://aol.com')
@@ -47,6 +47,6 @@ class TestMetaPassthroughMiddleware(TestCase):
 
         for item in self.mpm.process_spider_output(a, [r], MagicMock()):
             # key1 value1 did not pass through, since it was already set
-            self.assertEquals(item.meta['key1'], 'othervalue')
+            self.assertEqual(item.meta['key1'], 'othervalue')
             # key2 was not set, therefor it passed through
-            self.assertEquals(item.meta['key2'], 'value2')
+            self.assertEqual(item.meta['key2'], 'value2')

--- a/crawler/tests/test_redis_stats_middleware.py
+++ b/crawler/tests/test_redis_stats_middleware.py
@@ -25,12 +25,12 @@ class TestRedisStatsMiddleware(TestCase):
         # test nothing
         spider_name = 'link'
         self.rsm._setup_stats_status_codes(spider_name)
-        self.assertEquals(list(self.rsm.stats_dict[spider_name]['status_codes'].keys()), [])
+        self.assertEqual(list(self.rsm.stats_dict[spider_name]['status_codes'].keys()), [])
 
         # test status codes only
         self.rsm.settings['STATS_RESPONSE_CODES'] = [200, 403]
         self.rsm._setup_stats_status_codes(spider_name)
-        self.assertEquals(
+        self.assertEqual(
             sorted(self.rsm.stats_dict[spider_name]['status_codes'].keys()),
             sorted([200, 403]))
         self.assertEqual(list(self.rsm.stats_dict[spider_name]['status_codes'][200].keys()),
@@ -53,10 +53,10 @@ class TestRedisStatsMiddleware(TestCase):
 
         # check that both keys are set up
         self.rsm._setup_stats_status_codes(spider_name)
-        self.assertEquals(
+        self.assertEqual(
             sorted([str(x) for x in self.rsm.stats_dict[spider_name]['status_codes'][200].keys()]),
             sorted(good))
-        self.assertEquals(
+        self.assertEqual(
             sorted([str(x) for x in self.rsm.stats_dict[spider_name]['status_codes'][403].keys()]),
             sorted(good))
 
@@ -65,24 +65,24 @@ class TestRedisStatsMiddleware(TestCase):
 
         for time_key in self.rsm.stats_dict[spider_name]['status_codes'][200]:
             if time_key == 0:
-                self.assertEquals(
+                self.assertEqual(
                     self.rsm.stats_dict[spider_name]['status_codes'][200][0].key,
                     '{k}:lifetime'.format(k=k1)
                     )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     self.rsm.stats_dict[spider_name]['status_codes'][200][time_key].key,
                     '{k}:{t}'.format(k=k1, t=time_key)
                     )
 
         for time_key in self.rsm.stats_dict[spider_name]['status_codes'][403]:
             if time_key == 0:
-                self.assertEquals(
+                self.assertEqual(
                     self.rsm.stats_dict[spider_name]['status_codes'][403][0].key,
                     '{k}:lifetime'.format(k=k2)
                     )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     self.rsm.stats_dict[spider_name]['status_codes'][403][time_key].key,
                     '{k}:{t}'.format(k=k2, t=time_key)
                     )
@@ -141,6 +141,6 @@ class TestRedisStatsMiddleware(TestCase):
                 self.rsm.process_spider_input(response, spider)
 
         # 4 calls for link, 4 calls for wandering
-        self.assertEquals(fake_stats.increment.call_count, 8)
+        self.assertEqual(fake_stats.increment.call_count, 8)
 
 

--- a/kafka-monitor/tests/test_kafka_monitor.py
+++ b/kafka-monitor/tests/test_kafka_monitor.py
@@ -62,8 +62,8 @@ class TestKafkaMonitor(TestCase):
         self.kafka_monitor.settings['STATS_TIMES'] = []
         self.kafka_monitor._setup_stats_total(MagicMock())
 
-        self.assertEquals(list(self.kafka_monitor.stats_dict['total'].keys()), ['lifetime'])
-        self.assertEquals(list(self.kafka_monitor.stats_dict['fail'].keys()), ['lifetime'])
+        self.assertEqual(list(self.kafka_monitor.stats_dict['total'].keys()), ['lifetime'])
+        self.assertEqual(list(self.kafka_monitor.stats_dict['fail'].keys()), ['lifetime'])
 
         # test good/bad rolling stats
         self.kafka_monitor.stats_dict = {}
@@ -79,10 +79,10 @@ class TestKafkaMonitor(TestCase):
         ]
 
         self.kafka_monitor._setup_stats_total(MagicMock())
-        self.assertEquals(
+        self.assertEqual(
             sorted([str(x) for x in self.kafka_monitor.stats_dict['total'].keys()]),
             sorted(good))
-        self.assertEquals(
+        self.assertEqual(
             sorted([str(x) for x in self.kafka_monitor.stats_dict['fail'].keys()]),
             sorted(good))
 
@@ -91,24 +91,24 @@ class TestKafkaMonitor(TestCase):
 
         for time_key in self.kafka_monitor.stats_dict['total']:
             if time_key == 0:
-                self.assertEquals(
+                self.assertEqual(
                     self.kafka_monitor.stats_dict['total'][0].key,
                     '{k}:lifetime'.format(k=k1)
                     )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     self.kafka_monitor.stats_dict['total'][time_key].key,
                     '{k}:{t}'.format(k=k1, t=time_key)
                     )
 
         for time_key in self.kafka_monitor.stats_dict['fail']:
             if time_key == 0:
-                self.assertEquals(
+                self.assertEqual(
                     self.kafka_monitor.stats_dict['fail'][0].key,
                     '{k}:lifetime'.format(k=k2)
                     )
             else:
-                self.assertEquals(
+                self.assertEqual(
                     self.kafka_monitor.stats_dict['fail'][time_key].key,
                     '{k}:{t}'.format(k=k2, t=time_key)
                     )
@@ -129,13 +129,13 @@ class TestKafkaMonitor(TestCase):
             'ZookeeperHandler'
         ]
 
-        self.assertEquals(
+        self.assertEqual(
             sorted(list(self.kafka_monitor.stats_dict['plugins'].keys())),
             sorted(defaults))
 
         for key in self.kafka_monitor.plugins_dict:
             plugin_name = self.kafka_monitor.plugins_dict[key]['instance'].__class__.__name__
-            self.assertEquals(
+            self.assertEqual(
                 list(self.kafka_monitor.stats_dict['plugins'][plugin_name].keys()),
                 ['lifetime'])
 
@@ -154,13 +154,13 @@ class TestKafkaMonitor(TestCase):
 
         self.kafka_monitor._setup_stats_plugins(MagicMock())
 
-        self.assertEquals(
+        self.assertEqual(
             sorted(self.kafka_monitor.stats_dict['plugins'].keys()),
             sorted(defaults))
 
         for key in self.kafka_monitor.plugins_dict:
             plugin_name = self.kafka_monitor.plugins_dict[key]['instance'].__class__.__name__
-            self.assertEquals(
+            self.assertEqual(
                 sorted([str(x) for x in self.kafka_monitor.stats_dict['plugins'][plugin_name].keys()]),
                 sorted(good))
 
@@ -168,12 +168,12 @@ class TestKafkaMonitor(TestCase):
             k1 = 'stats:kafka-monitor:{p}'.format(p=plugin_key)
             for time_key in self.kafka_monitor.stats_dict['plugins'][plugin_key]:
                 if time_key == 0:
-                    self.assertEquals(
+                    self.assertEqual(
                         self.kafka_monitor.stats_dict['plugins'][plugin_key][0].key,
                         '{k}:lifetime'.format(k=k1)
                         )
                 else:
-                    self.assertEquals(
+                    self.assertEqual(
                         self.kafka_monitor.stats_dict['plugins'][plugin_key][time_key].key,
                         '{k}:{t}'.format(k=k1, t=time_key)
                         )
@@ -224,7 +224,7 @@ class TestKafkaMonitor(TestCase):
             self.kafka_monitor._process_messages()
             self.fail("Scrape not called")
         except AssertionError as e:
-            self.assertEquals("scrape", str(e))
+            self.assertEqual("scrape", str(e))
 
         # test that handler function is called for the actions
         message_string = "{\"uuid\":\"blah\",\"crawlid\":\"1234\"," \
@@ -237,5 +237,5 @@ class TestKafkaMonitor(TestCase):
             self.kafka_monitor._process_messages()
             self.fail("Action not called")
         except AssertionError as e:
-            self.assertEquals("action", str(e))
+            self.assertEqual("action", str(e))
 

--- a/kafka-monitor/tests/test_plugins.py
+++ b/kafka-monitor/tests/test_plugins.py
@@ -56,7 +56,7 @@ class TestPlugins(TestCase):
             handler.handle(valid)
             self.fail("Action not called")
         except AssertionError as e:
-            self.assertEquals("added", str(e))
+            self.assertEqual("added", str(e))
 
         # check timeout is added
         handler.redis_conn.zadd = MagicMock()
@@ -66,7 +66,7 @@ class TestPlugins(TestCase):
             handler.handle(valid)
             self.fail("Expires not called")
         except AssertionError as e:
-            self.assertEquals("expires", str(e))
+            self.assertEqual("expires", str(e))
 
     def test_action_handler(self):
         handler = ActionHandler()
@@ -85,7 +85,7 @@ class TestPlugins(TestCase):
             handler.handle(valid)
             self.fail("Added not called")
         except AssertionError as e:
-            self.assertEquals("added", str(e))
+            self.assertEqual("added", str(e))
 
     def test_stats_handler(self):
         handler = StatsHandler()
@@ -102,7 +102,7 @@ class TestPlugins(TestCase):
             handler.handle(valid)
             self.fail("Added not called")
         except AssertionError as e:
-            self.assertEquals("added", str(e))
+            self.assertEqual("added", str(e))
 
     def test_zookeeper_handler(self):
         handler = ZookeeperHandler()
@@ -123,7 +123,7 @@ class TestPlugins(TestCase):
             handler.handle(valid)
             self.fail("Added not called")
         except AssertionError as e:
-            self.assertEquals("added", str(e))
+            self.assertEqual("added", str(e))
 
     def test_bad_plugins(self):
         class ForgotSchema(BaseHandler):

--- a/redis-monitor/tests/online.py
+++ b/redis-monitor/tests/online.py
@@ -93,7 +93,7 @@ class TestRedisMonitor(TestCase):
         self.redis_monitor._process_plugin(plugin)
 
         # ensure the key is gone
-        self.assertEquals(self.redis_monitor.redis_conn.get(key), None)
+        self.assertEqual(self.redis_monitor.redis_conn.get(key), None)
         self.redis_monitor.close()
         sleep(10)
         # now test the message was sent to kafka
@@ -109,10 +109,10 @@ class TestRedisMonitor(TestCase):
             pass
         else:
             the_dict = json.loads(m.value)
-            self.assertEquals(success, the_dict)
+            self.assertEqual(success, the_dict)
             message_count += 1
 
-        self.assertEquals(message_count, 1)
+        self.assertEqual(message_count, 1)
 
     def tearDown(self):
         # if for some reason the tests fail, we end up falling behind on

--- a/redis-monitor/tests/test_plugins.py
+++ b/redis-monitor/tests/test_plugins.py
@@ -73,9 +73,9 @@ class TestInfoPlugin(TestCase, RegexFixer):
 
     def test_info_regex(self):
         regex = self.fix_re(self.plugin.regex)
-        self.assertEquals(re.findall(regex, 'info:stuff:stuff'), ['info:stuff:stuff'])
-        self.assertEquals(re.findall(regex, 'info:stuff:stuff:stuff'), ['info:stuff:stuff:stuff'])
-        self.assertEquals(re.findall(regex, 'info:stuff'), [])
+        self.assertEqual(re.findall(regex, 'info:stuff:stuff'), ['info:stuff:stuff'])
+        self.assertEqual(re.findall(regex, 'info:stuff:stuff:stuff'), ['info:stuff:stuff:stuff'])
+        self.assertEqual(re.findall(regex, 'info:stuff'), [])
 
     def test_info_get_bin(self):
         v1 = "stuff"
@@ -83,7 +83,7 @@ class TestInfoPlugin(TestCase, RegexFixer):
         v2 = 200
         self.plugin.redis_conn.zscan_iter = MagicMock(return_value=[(v1, v2)])
         ret_val = self.plugin._get_bin('key')
-        self.assertEquals(ret_val, {-200: ['stuff']})
+        self.assertEqual(ret_val, {-200: ['stuff']})
 
     def test_info_get_crawlid(self):
         master = {}
@@ -124,7 +124,7 @@ class TestInfoPlugin(TestCase, RegexFixer):
             'uuid': 'ABC123'
         }
 
-        self.assertEquals(result, success)
+        self.assertEqual(result, success)
 
     def test_info_get_appid(self):
         master = {}
@@ -165,7 +165,7 @@ class TestInfoPlugin(TestCase, RegexFixer):
                     'expires': 10
                 }}}
 
-        self.assertEquals(result, success)
+        self.assertEqual(result, success)
 
 
 class TestStopPlugin(TestCase, RegexFixer):
@@ -176,11 +176,11 @@ class TestStopPlugin(TestCase, RegexFixer):
 
     def test_stop_regex(self):
         regex = self.fix_re(self.plugin.regex)
-        self.assertEquals(re.findall(regex, 'stop:spider:app:crawl'),
+        self.assertEqual(re.findall(regex, 'stop:spider:app:crawl'),
                           ['stop:spider:app:crawl'])
-        self.assertEquals(re.findall(regex, 'stop:spider:app'),
+        self.assertEqual(re.findall(regex, 'stop:spider:app'),
                           ['stop:spider:app'])
-        self.assertEquals(re.findall(regex, 'stop:stuff'), [])
+        self.assertEqual(re.findall(regex, 'stop:stuff'), [])
 
     def test_stop_monitor_mini_purge(self):
         self.plugin.redis_conn.scan_iter = MagicMock(return_value=['link:istresearch.com:queue'])
@@ -189,7 +189,7 @@ class TestStopPlugin(TestCase, RegexFixer):
             ['{"crawlid":"crawl", "appid":"foo"}'],
         ])
 
-        self.assertEquals(self.plugin._mini_purge("link", "app", "crawl"), 1)
+        self.assertEqual(self.plugin._mini_purge("link", "app", "crawl"), 1)
 
 
 class TestExpirePlugin(TestCase, RegexFixer):
@@ -200,9 +200,9 @@ class TestExpirePlugin(TestCase, RegexFixer):
 
     def test_stop_regex(self):
         regex = self.fix_re(self.plugin.regex)
-        self.assertEquals(re.findall(regex, 'timeout:blah1:blah2:bla3'),
+        self.assertEqual(re.findall(regex, 'timeout:blah1:blah2:bla3'),
                           ['timeout:blah1:blah2:bla3'])
-        self.assertEquals(re.findall(regex, 'timeout:blah1:blah2'), [])
+        self.assertEqual(re.findall(regex, 'timeout:blah1:blah2'), [])
 
     def test_expire_monitor_time(self):
         # if the stop monitor passes then this is just testing whether
@@ -222,7 +222,7 @@ class TestExpirePlugin(TestCase, RegexFixer):
                 self.plugin.handle("key:stuff:blah:blah", 4)
             self.fail("Expire not called")
         except BaseException as e:
-            self.assertEquals("throw once", str(e))
+            self.assertEqual("throw once", str(e))
 
 class TestStatsPlugin(TestCase, RegexFixer):
     def setUp(self):
@@ -233,16 +233,16 @@ class TestStatsPlugin(TestCase, RegexFixer):
 
     def test_stats_regex(self):
         regex = self.fix_re(self.plugin.regex)
-        self.assertEquals(re.findall(regex, 'statsrequest:crawler:testApp'),
+        self.assertEqual(re.findall(regex, 'statsrequest:crawler:testApp'),
                           ['statsrequest:crawler:testApp'])
-        self.assertEquals(re.findall(regex, 'statsrequest:crawler'), [])
+        self.assertEqual(re.findall(regex, 'statsrequest:crawler'), [])
 
     def _assert_thrown(self, key, equals):
         try:
             self.plugin.handle(key, 'blah')
             self.fail(equals + " exception not thrown")
         except Exception as e:
-            self.assertEquals(equals, str(e))
+            self.assertEqual(equals, str(e))
 
     def test_stats_handle(self):
         # trying to make sure that everything is called
@@ -291,7 +291,7 @@ class TestStatsPlugin(TestCase, RegexFixer):
                 }
             }
         }
-        self.assertEquals(result, good)
+        self.assertEqual(result, good)
 
     def test_stats_get_machine(self):
         # tests stats on three different machines, with different spiders
@@ -313,7 +313,7 @@ class TestStatsPlugin(TestCase, RegexFixer):
                 'host3': {'200': {'86400': 5}}
             }
         }
-        self.assertEquals(result, good)
+        self.assertEqual(result, good)
 
     def test_stats_get_queue(self):
         # tests stats on three different machines, with different spiders
@@ -355,7 +355,7 @@ class TestStatsPlugin(TestCase, RegexFixer):
                 }
             }
         }
-        self.assertEquals(result, good)
+        self.assertEqual(result, good)
 
     def test_stats_get_plugin(self):
         self.plugin.redis_conn.keys = MagicMock(return_value=[
@@ -374,7 +374,7 @@ class TestStatsPlugin(TestCase, RegexFixer):
             "total": {"lifetime": 5, "3600": 5},
             "fail": {"68000": 5, "3600": 5}
         }
-        self.assertEquals(result, good)
+        self.assertEqual(result, good)
 
 class TestZookeeperPlugin(TestCase, RegexFixer):
     def setUp(self):
@@ -389,9 +389,9 @@ class TestZookeeperPlugin(TestCase, RegexFixer):
 
     def test_zk_regex(self):
         regex = self.fix_re(self.plugin.regex)
-        self.assertEquals(re.findall(regex, 'zk:blah1:blah2:bla3'),
+        self.assertEqual(re.findall(regex, 'zk:blah1:blah2:bla3'),
                           ['zk:blah1:blah2:bla3'])
-        self.assertEquals(re.findall(regex, 'zk:blah1:blah2'), [])
+        self.assertEqual(re.findall(regex, 'zk:blah1:blah2'), [])
 
     def test_zk_handle_du(self):
         # domain update

--- a/redis-monitor/tests/test_redis_monitor.py
+++ b/redis-monitor/tests/test_redis_monitor.py
@@ -64,7 +64,7 @@ class TestRedisMonitor(TestCase):
             self.redis_monitor._process_plugin(plugin)
             self.fail("Info not called")
         except BaseException as e:
-            self.assertEquals("info", str(e))
+            self.assertEqual("info", str(e))
 
         # action
         try:
@@ -72,7 +72,7 @@ class TestRedisMonitor(TestCase):
             self.redis_monitor._process_plugin(plugin)
             self.fail("Stop not called")
         except BaseException as e:
-            self.assertEquals("stop", str(e))
+            self.assertEqual("stop", str(e))
 
         # expire
         try:
@@ -80,7 +80,7 @@ class TestRedisMonitor(TestCase):
             self.redis_monitor._process_plugin(plugin)
             self.fail("Expire not called")
         except BaseException as e:
-            self.assertEquals("expire", str(e))
+            self.assertEqual("expire", str(e))
 
         # test that an exception within a handle method is caught
         self.redis_monitor._process_failures = MagicMock()
@@ -158,13 +158,13 @@ class TestRedisMonitor(TestCase):
             'ZookeeperMonitor'
         ]
 
-        self.assertEquals(
+        self.assertEqual(
             sorted(self.redis_monitor.stats_dict['plugins'].keys()),
             sorted(defaults))
 
         for key in self.redis_monitor.plugins_dict:
             plugin_name = self.redis_monitor.plugins_dict[key]['instance'].__class__.__name__
-            self.assertEquals(
+            self.assertEqual(
                 list(self.redis_monitor.stats_dict['plugins'][plugin_name].keys()),
                 ['lifetime'])
 
@@ -183,13 +183,13 @@ class TestRedisMonitor(TestCase):
 
         self.redis_monitor._setup_stats_plugins()
 
-        self.assertEquals(
+        self.assertEqual(
             sorted(self.redis_monitor.stats_dict['plugins'].keys()),
             sorted(defaults))
 
         for key in self.redis_monitor.plugins_dict:
             plugin_name = self.redis_monitor.plugins_dict[key]['instance'].__class__.__name__
-            self.assertEquals(
+            self.assertEqual(
                 sorted([str(x) for x in self.redis_monitor.stats_dict['plugins'][plugin_name].keys()]),
                 sorted(good))
 
@@ -197,12 +197,12 @@ class TestRedisMonitor(TestCase):
             k1 = 'stats:redis-monitor:{p}'.format(p=plugin_key)
             for time_key in self.redis_monitor.stats_dict['plugins'][plugin_key]:
                 if time_key == 0:
-                    self.assertEquals(
+                    self.assertEqual(
                         self.redis_monitor.stats_dict['plugins'][plugin_key][0].key,
                         '{k}:lifetime'.format(k=k1)
                         )
                 else:
-                    self.assertEquals(
+                    self.assertEqual(
                         self.redis_monitor.stats_dict['plugins'][plugin_key][time_key].key,
                         '{k}:{t}'.format(k=k1, t=time_key)
                         )
@@ -216,7 +216,7 @@ class TestRedisMonitor(TestCase):
             self.redis_monitor._main_loop()
             self.fail("_process_plugin not called")
         except BaseException as e:
-            self.assertEquals("normal", str(e))
+            self.assertEqual("normal", str(e))
 
     def test_precondition(self):
         self.redis_monitor.stats_dict = {}
@@ -235,12 +235,12 @@ class TestRedisMonitor(TestCase):
             self.redis_monitor._process_key_val(instance, key, value)
             self.fail('handler not called')
         except BaseException as e:
-            self.assertEquals('handler', str(e))
+            self.assertEqual('handler', str(e))
 
     def test_get_fail_key(self):
         key = 'test'
         result = 'lock:test:failures'
-        self.assertEquals(self.redis_monitor._get_fail_key(key), result)
+        self.assertEqual(self.redis_monitor._get_fail_key(key), result)
 
     def test_process_failures(self):
         self.redis_monitor.settings = {'RETRY_FAILURES':True,

--- a/rest/tests/online.py
+++ b/rest/tests/online.py
@@ -39,7 +39,7 @@ class TestRestService(TestCase):
         r = requests.get('http://127.0.0.1:{p}'.format(p=self.port_number))
         results = r.json()
 
-        self.assertEquals(results['node_health'], 'GREEN')
+        self.assertEqual(results['node_health'], 'GREEN')
 
     def tearDown(self):
         self.rest_service.close()

--- a/rest/tests/test_rest_service.py
+++ b/rest/tests/test_rest_service.py
@@ -61,7 +61,7 @@ class TestRestService(TestCase):
     @mock.patch('six.moves.builtins.open', mock_open(read_data='{\"stuff\":\"value\"}'), create=True)
     def test_load_schemas_bad(self):
         self.rest_service._load_schemas()
-        self.assertEquals(self.rest_service.schemas,
+        self.assertEqual(self.rest_service.schemas,
                           {'hey2': {u'stuff': u'value'}})
 
     def test_process_messages(self):
@@ -110,7 +110,7 @@ class TestRestService(TestCase):
         m.value = message_string
         messages = [m]
         self.rest_service._process_messages()
-        self.assertEquals(self.rest_service.uuids, {'abc123': {u'uuid': u'abc123'}})
+        self.assertEqual(self.rest_service.uuids, {'abc123': {u'uuid': u'abc123'}})
 
     def test_send_result_to_redis(self):
         # test not connected
@@ -216,8 +216,8 @@ class TestRestService(TestCase):
             self.rest_service._setup_kafka()
         except:
             pass
-        self.assertEquals(self.rest_service.consumer, None)
-        self.assertEquals(self.rest_service.producer, None)
+        self.assertEqual(self.rest_service.consumer, None)
+        self.assertEqual(self.rest_service.producer, None)
 
         # test if everything flows through
         self.rest_service._create_consumer = MagicMock()
@@ -232,7 +232,7 @@ class TestRestService(TestCase):
             "data": None,
             "error": None
         }
-        self.assertEquals(self.rest_service._create_ret_object(status=self.rest_service.FAILURE), r)
+        self.assertEqual(self.rest_service._create_ret_object(status=self.rest_service.FAILURE), r)
 
         # success
         r = {
@@ -240,7 +240,7 @@ class TestRestService(TestCase):
             "data": None,
             "error": None
         }
-        self.assertEquals(self.rest_service._create_ret_object(status=self.rest_service.SUCCESS), r)
+        self.assertEqual(self.rest_service._create_ret_object(status=self.rest_service.SUCCESS), r)
 
         # data
         r = {
@@ -248,7 +248,7 @@ class TestRestService(TestCase):
             "data": 'blah',
             "error": None
         }
-        self.assertEquals(self.rest_service._create_ret_object(status=self.rest_service.SUCCESS, data='blah'), r)
+        self.assertEqual(self.rest_service._create_ret_object(status=self.rest_service.SUCCESS, data='blah'), r)
 
         # error message
         r = {
@@ -258,7 +258,7 @@ class TestRestService(TestCase):
                 "message": 'err'
             }
         }
-        self.assertEquals(self.rest_service._create_ret_object(status=self.rest_service.FAILURE,
+        self.assertEqual(self.rest_service._create_ret_object(status=self.rest_service.FAILURE,
                                                                error=True,
                                                                error_message='err'), r)
 
@@ -271,7 +271,7 @@ class TestRestService(TestCase):
                 "cause": "the cause"
             }
         }
-        self.assertEquals(self.rest_service._create_ret_object(status=self.rest_service.FAILURE,
+        self.assertEqual(self.rest_service._create_ret_object(status=self.rest_service.FAILURE,
                                                                error=True,
                                                                error_message='err',
                                                                error_cause="the cause"), r)
@@ -306,7 +306,7 @@ class TestRestService(TestCase):
         self.rest_service._close_thread = MagicMock()
         self.rest_service.close()
 
-        self.assertEquals(self.rest_service._close_thread.call_count, 4)
+        self.assertEqual(self.rest_service._close_thread.call_count, 4)
         self.assertTrue(self.rest_service.closed)
         self.assertTrue(self.rest_service.consumer.close.called)
         self.assertTrue(self.rest_service.producer.close.called)
@@ -314,19 +314,19 @@ class TestRestService(TestCase):
     def test_calculate_health(self):
         self.rest_service.redis_connected = False
         self.rest_service.kafka_connected = False
-        self.assertEquals(self.rest_service._calculate_health(), "RED")
+        self.assertEqual(self.rest_service._calculate_health(), "RED")
 
         self.rest_service.redis_connected = True
         self.rest_service.kafka_connected = False
-        self.assertEquals(self.rest_service._calculate_health(), "YELLOW")
+        self.assertEqual(self.rest_service._calculate_health(), "YELLOW")
 
         self.rest_service.redis_connected = False
         self.rest_service.kafka_connected = True
-        self.assertEquals(self.rest_service._calculate_health(), "YELLOW")
+        self.assertEqual(self.rest_service._calculate_health(), "YELLOW")
 
         self.rest_service.redis_connected = True
         self.rest_service.kafka_connected = True
-        self.assertEquals(self.rest_service._calculate_health(), "GREEN")
+        self.assertEqual(self.rest_service._calculate_health(), "GREEN")
 
     def test_feed_to_kafka(self):
         self.rest_service.producer = MagicMock()
@@ -352,7 +352,7 @@ class TestRestService(TestCase):
             override.test_log_call()
 
         self.assertTrue(override.logger.info.called)
-        self.assertEquals(override.logger.info.call_args[0][0], "test logger")
+        self.assertEqual(override.logger.info.call_args[0][0], "test logger")
 
     def test_error_catch(self):
         override = Override('settings.py')
@@ -363,7 +363,7 @@ class TestRestService(TestCase):
             override.logger.error = MagicMock()
             results = override.test_error1()
             self.assertTrue(override.logger.error.called)
-            self.assertEquals(override.logger.error.call_args[0][0],
+            self.assertEqual(override.logger.error.call_args[0][0],
                               "Uncaught Exception Thrown")
             d = {
                 u'data': None,
@@ -373,8 +373,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 500)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 500)
 
         # test normal response
         with self.rest_service.app.test_request_context():
@@ -382,8 +382,8 @@ class TestRestService(TestCase):
             results = override.test_error2()
             self.assertFalse(override.logger.error.called)
             data = json.loads(results[0].data)
-            self.assertEquals(data, 'test data')
-            self.assertEquals(results[1], 200)
+            self.assertEqual(data, 'test data')
+            self.assertEqual(results[1], 200)
 
         # test normal response with alternate response code
         with self.rest_service.app.test_request_context():
@@ -391,8 +391,8 @@ class TestRestService(TestCase):
             results = override.test_error3()
             self.assertFalse(override.logger.error.called)
             data = json.loads(results[0].data)
-            self.assertEquals(data, 'test data')
-            self.assertEquals(results[1], 109)
+            self.assertEqual(data, 'test data')
+            self.assertEqual(results[1], 109)
 
     def test_validate_json(self):
         override = Override('settings.py')
@@ -404,7 +404,7 @@ class TestRestService(TestCase):
                                                         content_type='application/json'):
             results = override.test_json()
             self.assertTrue(override.logger.error.called)
-            self.assertEquals(override.logger.error.call_args[0][0],
+            self.assertEqual(override.logger.error.call_args[0][0],
                               'The payload must be valid JSON.')
 
             d = {
@@ -415,8 +415,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 400)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 400)
 
         # no json
         data = '["a list", ashdasd ,\\ !]'
@@ -424,7 +424,7 @@ class TestRestService(TestCase):
             self.rest_service.logger.error.reset_mock()
             results = override.test_json()
             self.assertTrue(override.logger.error.called)
-            self.assertEquals(override.logger.error.call_args[0][0],
+            self.assertEqual(override.logger.error.call_args[0][0],
                               'The payload must be valid JSON.')
 
             d = {
@@ -435,8 +435,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 400)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 400)
 
         # good json
         data = '["a list", "2", "3"]'
@@ -445,7 +445,7 @@ class TestRestService(TestCase):
             override.logger.reset_mock()
             results = override.test_json()
             self.assertFalse(override.logger.error.called)
-            self.assertEquals(results, 'data')
+            self.assertEqual(results, 'data')
 
     def test_validate_schema(self):
         override = Override('settings.py')
@@ -473,7 +473,7 @@ class TestRestService(TestCase):
                                                         content_type='application/json'):
             results = override.test_schema()
             self.assertFalse(override.logger.error.called)
-            self.assertEquals(results, 'data')
+            self.assertEqual(results, 'data')
 
         # invalid schema
         data = u'{"value": "data here", "otherkey": "bad data"}'
@@ -481,7 +481,7 @@ class TestRestService(TestCase):
                                                         content_type='application/json'):
             results = override.test_schema()
             self.assertTrue(override.logger.error.called)
-            self.assertEquals(override.logger.error.call_args[0][0],
+            self.assertEqual(override.logger.error.call_args[0][0],
                               "Invalid Schema")
 
             if six.PY3:
@@ -497,8 +497,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 400)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 400)
 
     # Routes ------------------
 
@@ -515,7 +515,7 @@ class TestRestService(TestCase):
                 "node_health": 'RED'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
+            self.assertEqual(data, d)
 
     def test_feed(self):
         # test not connected
@@ -534,8 +534,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 500)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 500)
 
         # connected
         self.rest_service.kafka_connected = True
@@ -554,8 +554,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 500)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 500)
 
         # test no uuid
         self.rest_service._feed_to_kafka = MagicMock(return_value=True)
@@ -568,8 +568,8 @@ class TestRestService(TestCase):
                 u'status': u'SUCCESS'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 200)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 200)
 
         # test with uuid, got response
         time_list = [0, 1, 2, 3, 4, 5]
@@ -590,8 +590,8 @@ class TestRestService(TestCase):
                 u'status': u'SUCCESS'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 200)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 200)
             self.assertFalse('key' in self.rest_service.uuids)
 
         # test with uuid, no response
@@ -609,10 +609,10 @@ class TestRestService(TestCase):
                 u'status': u'SUCCESS'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 200)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 200)
             self.assertTrue('key' in self.rest_service.uuids)
-            self.assertEquals(self.rest_service.uuids['key'], 'poll')
+            self.assertEqual(self.rest_service.uuids['key'], 'poll')
 
     def test_poll(self):
         orig = self.rest_service.validator
@@ -635,8 +635,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 500)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 500)
 
         # test connected found poll key
         self.rest_service.redis_conn = MagicMock()
@@ -651,8 +651,8 @@ class TestRestService(TestCase):
                 u'status': u'SUCCESS'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 200)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 200)
 
         # test connected didnt find poll key
         self.rest_service.redis_conn.get = MagicMock(return_value=None)
@@ -668,8 +668,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 404)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 404)
 
         # test connection error
         self.rest_service._spawn_redis_connection_thread = MagicMock()
@@ -679,7 +679,7 @@ class TestRestService(TestCase):
             self.rest_service.redis_conn.get = MagicMock(side_effect=ConnectionError)
             results = self.rest_service.poll()
             self.assertTrue(self.rest_service.logger.error.called)
-            self.assertEquals(self.rest_service.logger.error.call_args[0][0], "Lost connection to Redis")
+            self.assertEqual(self.rest_service.logger.error.call_args[0][0], "Lost connection to Redis")
             self.assertTrue(self.rest_service._spawn_redis_connection_thread.called)
 
             d = {
@@ -690,8 +690,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 500)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 500)
 
         # test value error
         self.rest_service.logger.warning = MagicMock()
@@ -700,7 +700,7 @@ class TestRestService(TestCase):
             self.rest_service.redis_conn.get = MagicMock(side_effect=ValueError)
             results = self.rest_service.poll()
             self.assertTrue(self.rest_service.logger.warning.called)
-            self.assertEquals(self.rest_service.logger.warning.call_args[0][0], "Unparseable JSON Received from redis")
+            self.assertEqual(self.rest_service.logger.warning.call_args[0][0], "Unparseable JSON Received from redis")
 
             d = {
                 u'data': None,
@@ -710,8 +710,8 @@ class TestRestService(TestCase):
                 u'status': u'FAILURE'
             }
             data = json.loads(results[0].data)
-            self.assertEquals(data, d)
-            self.assertEquals(results[1], 500)
+            self.assertEqual(data, d)
+            self.assertEqual(results[1], 500)
 
         self.rest_service.validator = orig
 

--- a/utils/tests/online.py
+++ b/utils/tests/online.py
@@ -405,10 +405,10 @@ class TestZookeeperWatcher(TestCase):
                                                ensure=False,
                                                valid_init=True)
 
-        self.assertEquals(self.zoo_watcher.get_file_contents(), self.file_data)
-        self.assertEquals(pointer_zoo_watcher.get_file_contents(),
+        self.assertEqual(self.zoo_watcher.get_file_contents(), self.file_data)
+        self.assertEqual(pointer_zoo_watcher.get_file_contents(),
                           self.file_data)
-        self.assertEquals(pointer_zoo_watcher.get_file_contents(True),
+        self.assertEqual(pointer_zoo_watcher.get_file_contents(True),
                           self.pointer_data)
 
         pointer_zoo_watcher.close()

--- a/utils/tests/test_log_factory.py
+++ b/utils/tests/test_log_factory.py
@@ -313,8 +313,8 @@ class TestLogCallbacks(TestCase):
         extras = {"key": "value", 'a': [1, 2, 3]}
 
         def cb(log_message=None, log_extra=None):
-            self.assertEquals(log_message, message)
-            self.assertEquals(log_extra, extras)
+            self.assertEqual(log_message, message)
+            self.assertEqual(log_extra, extras)
 
         self.logger.register_callback('>DEBUG', cb)
         self.logger.log_level = 'INFO'

--- a/utils/tests/test_redis_queue.py
+++ b/utils/tests/test_redis_queue.py
@@ -30,16 +30,16 @@ class TestBase(TestCase):
         q = Base(MagicMock(), 'key', pickle)
         # python pickling is different between versions
         data = pickle.dumps('cool', protocol=-1).decode('latin1')
-        self.assertEquals(q._encode_item('cool'), data)
+        self.assertEqual(q._encode_item('cool'), data)
         q2 = Base(MagicMock(), 'key', ujson)
-        self.assertEquals(q2._encode_item('cool2'), '"cool2"')
+        self.assertEqual(q2._encode_item('cool2'), '"cool2"')
 
     def test_decode(self):
         q = Base(MagicMock(), 'key', pickle)
-        self.assertEquals(q._decode_item(u"\x80\x02U\x04coolq\x00."), 'cool')
+        self.assertEqual(q._decode_item(u"\x80\x02U\x04coolq\x00."), 'cool')
 
         q2 = Base(MagicMock(), 'key', ujson)
-        self.assertEquals(q2._decode_item('"cool2"'), 'cool2')
+        self.assertEqual(q2._decode_item('"cool2"'), 'cool2')
 
     def test_len(self):
         with self.assertRaises(NotImplementedError):
@@ -79,7 +79,7 @@ class TestRedisQueue(QueueMixin, TestCase):
     def test_pop(self):
         self.assertTrue(hasattr(self.queue, 'pop'))
         self.queue.server.rpop = MagicMock(return_value='"stuff"')
-        self.assertEquals(self.queue.pop(), "stuff")
+        self.assertEqual(self.queue.pop(), "stuff")
 
 
 class TestRedisPriorityQueue(QueueMixin, TestCase):
@@ -99,7 +99,7 @@ class TestRedisPriorityQueue(QueueMixin, TestCase):
         m = MagicMock()
         m.execute = MagicMock(return_value=[{}, 60])
         self.queue.server.pipeline = MagicMock(return_value=m)
-        self.assertEquals(self.queue.pop(), None)
+        self.assertEqual(self.queue.pop(), None)
 
 
 class TestRedisStack(QueueMixin, TestCase):
@@ -117,4 +117,4 @@ class TestRedisStack(QueueMixin, TestCase):
     def test_pop(self):
         self.assertTrue(hasattr(self.queue, 'pop'))
         self.queue.server.lpop = MagicMock(return_value='"stuff"')
-        self.assertEquals(self.queue.pop(), "stuff")
+        self.assertEqual(self.queue.pop(), "stuff")

--- a/utils/tests/test_zookeeper_watcher.py
+++ b/utils/tests/test_zookeeper_watcher.py
@@ -30,13 +30,13 @@ class TestZookeeperWatcher(TestCase):
         self.zoo_watcher.old_data = 'old_data'
 
         self.zoo_watcher.pointer = False
-        self.assertEquals(self.zoo_watcher.get_file_contents(), 'old_data')
+        self.assertEqual(self.zoo_watcher.get_file_contents(), 'old_data')
 
         self.zoo_watcher.pointer = True
-        self.assertEquals(self.zoo_watcher.get_file_contents(), 'old_data')
+        self.assertEqual(self.zoo_watcher.get_file_contents(), 'old_data')
 
         self.zoo_watcher.pointer = True
-        self.assertEquals(self.zoo_watcher.get_file_contents(True), 'old_pointed')
+        self.assertEqual(self.zoo_watcher.get_file_contents(True), 'old_pointed')
 
     def test_compare_pointer(self):
         self.zoo_watcher.old_pointed = '/path1'


### PR DESCRIPTION
Replaced and verified deprecated assertEquals, mainly for py3.