### PR TITLE
Add auto encoding resolution for crawling items.

### DIFF
--- a/crawler/crawling/items.py
+++ b/crawler/crawling/items.py
@@ -19,3 +19,4 @@ class RawResponseItem(Item):
     attrs = Field()
     success = Field()
     exception = Field()
+    encoding = Field()

--- a/crawler/crawling/pipelines.py
+++ b/crawler/crawling/pipelines.py
@@ -181,10 +181,13 @@ class KafkaPipeline(object):
             prefix = self.topic_prefix
 
             try:
-                if self.use_base64 and 'encoding' in datum:
-                    datum['body'] = base64.b64encode(bytes(datum['body']))
-                elif self.use_base64:
-                    datum['body'] = base64.b64encode(bytes(datum['body'], 'utf-8'))
+                if self.use_base64:
+                    if isinstance(datum['body'], str):
+                        datum['body'] = bytes(datum['body'], datum['encoding'])
+                    datum['body'] = base64.b64encode(datum['body'])
+                elif 'encoding' in datum and 'utf-8' != datum['encoding'] and datum['encoding']:
+                    datum['body'] = datum['body'].decode(datum['encoding'])
+
                 message = ujson.dumps(datum, sort_keys=True)
             except:
                 message = 'json failed to parse'

--- a/crawler/crawling/pipelines.py
+++ b/crawler/crawling/pipelines.py
@@ -181,11 +181,17 @@ class KafkaPipeline(object):
             prefix = self.topic_prefix
 
             try:
+                # Get the encoding. If it's not a key of datum, return utf-8
+                encoding = datum.get('encoding', 'utf-8')
+
                 if self.use_base64:
+                    # When running in Python 2 datum['body'] is a string
                     if isinstance(datum['body'], str):
-                        datum['body'] = bytes(datum['body'], datum['encoding'])
+                        datum['body'] = bytes(datum['body'], encoding)
+                    # In Python 3 datum['body'] is already in byte form
                     datum['body'] = base64.b64encode(datum['body'])
-                elif 'encoding' in datum and 'utf-8' != datum['encoding'] and datum['encoding']:
+
+                elif 'utf-8' != encoding:
                     datum['body'] = datum['body'].decode(datum['encoding'])
 
                 message = ujson.dumps(datum, sort_keys=True)

--- a/crawler/crawling/pipelines.py
+++ b/crawler/crawling/pipelines.py
@@ -181,7 +181,9 @@ class KafkaPipeline(object):
             prefix = self.topic_prefix
 
             try:
-                if self.use_base64:
+                if self.use_base64 and 'encoding' in datum:
+                    datum['body'] = base64.b64encode(bytes(datum['body']))
+                elif self.use_base64:
                     datum['body'] = base64.b64encode(bytes(datum['body'], 'utf-8'))
                 message = ujson.dumps(datum, sort_keys=True)
             except:

--- a/crawler/crawling/spiders/link_spider.py
+++ b/crawler/crawling/spiders/link_spider.py
@@ -40,6 +40,7 @@ class LinkSpider(RedisSpider):
         item["response_headers"] = self.reconstruct_headers(response)
         item["request_headers"] = response.request.headers
         item["body"] = response.body
+        item["encoding"] = response.encoding
         item["links"] = []
 
         # determine whether to continue spidering

--- a/crawler/crawling/spiders/wandering_spider.py
+++ b/crawler/crawling/spiders/wandering_spider.py
@@ -46,6 +46,7 @@ class WanderingSpider(RedisSpider):
         item["response_headers"] = self.reconstruct_headers(response)
         item["request_headers"] = response.request.headers
         item["body"] = response.body
+        item["encoding"] = response.encoding
         item["links"] = []
         # we want to know how far our spider gets
         if item['attrs'] is None:

--- a/crawler/tests/online.py
+++ b/crawler/tests/online.py
@@ -38,7 +38,7 @@ class TestLinkSpider(TestCase):
         "crawlid\":\"abc12345\",\"url\":\"istresearch.com\",\"expires\":0,\""\
         "ts\":1461549923.7956631184,\"priority\":1,\"deny_regex\":null,\""\
         "cookie\":null,\"attrs\":null,\"appid\":\"test\",\"spiderid\":\""\
-        "link\",\"useragent\":null,\"deny_extensions\":null,\"maxdepth\":0}"
+        "test-spider\",\"useragent\":null,\"deny_extensions\":null,\"maxdepth\":0}"
 
     def setUp(self):
         self.settings = get_project_settings()

--- a/crawler/tests/test_pipelines.py
+++ b/crawler/tests/test_pipelines.py
@@ -1,6 +1,9 @@
+# coding=utf-8
 from builtins import object
 from unittest import TestCase
 import mock
+import ujson
+import base64
 from mock import MagicMock
 from crawling.pipelines import (LoggingBeforePipeline, KafkaPipeline)
 from crawling.items import RawResponseItem
@@ -24,6 +27,43 @@ class ItemMixin(object):
         item["request_headers"] = {}
         item["body"] = "text"
         item["links"] = []
+        item["encoding"] = "utf-8"
+
+        return item
+
+    def _get_internationalized_utf8_item(self):
+        item = RawResponseItem()
+        item['appid'] = 'app'
+        item['crawlid'] = 'crawlid'
+        item['attrs'] = {}
+        item["url"] = "http://dumb.com"
+        item["response_url"] = "http://dumb.com"
+        item["status_code"] = 200
+        item["status_msg"] = "OK"
+        item["response_headers"] = {}
+        item["request_headers"] = {}
+        item["body"] = u"This is a test - Αυτό είναι ένα τεστ - 这是一个测试 - これはテストです"
+        item["links"] = []
+        item["encoding"] = "utf-8"
+
+        return item
+
+    def _get_internationalized_iso_item(self):
+        item = RawResponseItem()
+        item['appid'] = 'app'
+        item['crawlid'] = 'crawlid'
+        item['attrs'] = {}
+        item["url"] = "http://dumb.com"
+        item["response_url"] = "http://dumb.com"
+        item["status_code"] = 200
+        item["status_msg"] = "OK"
+        item["response_headers"] = {}
+        item["request_headers"] = {}
+        # Fill the item["body"] with the string 'αυτό είναι ένα τεστ' that was encoded in iso-8859-7
+        # using iconv and further encoded in base64 in order to store it inside this file.
+        item["body"] = base64.b64decode('4fX0/CDl3+3h6SDd7eEg9OXz9Ao=')
+        item["links"] = []
+        item["encoding"] = "iso-8859-7"
 
         return item
 
@@ -75,7 +115,7 @@ class TestKafkaPipeline(TestCase, ItemMixin):
 
         # test normal send, no appid topics
         self.pipe.process_item(item, spider)
-        expected = '{"appid":"app","attrs":{},"body":"text","crawlid":"crawlid","links":[],"request_headers":{},"response_headers":{},"response_url":"http:\\/\\/dumb.com","status_code":200,"status_msg":"OK","timestamp":"the time","url":"http:\\/\\/dumb.com"}'
+        expected = '{"appid":"app","attrs":{},"body":"text","crawlid":"crawlid","encoding":"utf-8","links":[],"request_headers":{},"response_headers":{},"response_url":"http:\\/\\/dumb.com","status_code":200,"status_msg":"OK","timestamp":"the time","url":"http:\\/\\/dumb.com"}'
         self.pipe.producer.send.assert_called_once_with('prefix.crawled_firehose',
                                                         expected)
         self.pipe.producer.send.reset_mock()
@@ -93,9 +133,39 @@ class TestKafkaPipeline(TestCase, ItemMixin):
         self.pipe.appid_topics = False
         self.pipe.use_base64 = True
         self.pipe.process_item(item, spider)
-        expected = '{"appid":"app","attrs":{},"body":"dGV4dA==","crawlid":"crawlid","links":[],"request_headers":{},"response_headers":{},"response_url":"http:\\/\\/dumb.com","status_code":200,"status_msg":"OK","timestamp":"the time","url":"http:\\/\\/dumb.com"}'
-        self.pipe.producer.send.assert_called_once_with('prefix.crawled_firehose',
+        expected = '{"appid":"app","attrs":{},"body":"dGV4dA==","crawlid":"crawlid","encoding":"utf-8","links":[],"request_headers":{},"response_headers":{},"response_url":"http:\\/\\/dumb.com","status_code":200,"status_msg":"OK","timestamp":"the time","url":"http:\\/\\/dumb.com"}'
+        self.pipe.producer.send.assert_called_with('prefix.crawled_firehose',
                                                         expected)
+
+        # test base64 encode/decode with utf-8 encoding
+        item = self._get_internationalized_utf8_item()
+        self.pipe.appid_topics = False
+        self.pipe.use_base64 = True
+        self.pipe.process_item(item, spider)
+        expected = '{"appid":"app","attrs":{},"body":"VGhpcyBpcyBhIHRlc3QgLSDOkc+Fz4TPjCDOtc6vzr3Osc65IM6tzr3OsSDPhM61z4PPhCAtIOi\\/meaYr+S4gOS4qua1i+ivlSAtIOOBk+OCjOOBr+ODhuOCueODiOOBp+OBmQ==","crawlid":"crawlid","encoding":"utf-8","links":[],"request_headers":{},"response_headers":{},"response_url":"http:\\/\\/dumb.com","status_code":200,"status_msg":"OK","timestamp":"the time","url":"http:\\/\\/dumb.com"}'
+        self.pipe.producer.send.assert_called_with('prefix.crawled_firehose',
+                                                        expected)
+        # unpack the arguments used for the previous assertion call
+        call_args, call_kwargs = self.pipe.producer.send.call_args
+        crawl_args_dict = ujson.loads(call_args[1])
+        decoded_string = base64.b64decode(crawl_args_dict['body']).decode(crawl_args_dict['encoding'])
+        self.assertEquals(decoded_string, item.get('body'))
+
+        # test base64 encode/decode with iso encoding
+        item = self._get_internationalized_iso_item()
+        self.pipe.appid_topics = False
+        self.pipe.use_base64 = True
+        self.pipe.process_item(item, spider)
+        expected = '{"appid":"app","attrs":{},"body":"4fX0\\/CDl3+3h6SDd7eEg9OXz9Ao=","crawlid":"crawlid","encoding":"iso-8859-7","links":[],"request_headers":{},"response_headers":{},"response_url":"http:\\/\\/dumb.com","status_code":200,"status_msg":"OK","timestamp":"the time","url":"http:\\/\\/dumb.com"}'
+        self.pipe.producer.send.assert_called_with('prefix.crawled_firehose',
+                                                   expected)
+        # unpack the arguments used for the previous assertion call
+        call_args, call_kwargs = self.pipe.producer.send.call_args
+        crawl_args_dict = ujson.loads(call_args[1])
+        decoded_string = base64.b64decode(crawl_args_dict['body']).decode(crawl_args_dict['encoding'])
+        self.assertEquals(decoded_string, item.get('body').decode(item.get('encoding')))
+        # Test again against the original (before it was encoded in iso) string
+        self.assertEquals(decoded_string, u"αυτό είναι ένα τεστ\n")
 
         # test kafka exception
         item = self._get_item()

--- a/kafka-monitor/kafkadump.py
+++ b/kafka-monitor/kafkadump.py
@@ -126,7 +126,9 @@ def main():
                     val = message.value
                     try:
                         item = json.loads(val)
-                        if args['decode_base64'] and 'body' in item:
+                        if args['decode_base64'] and 'body' in item and 'encoding' in item:
+                            item['body'] = base64.b64decode(item['body']).decode(item['encoding'])
+                        elif args['decode_base64'] and 'body' in item:
                             item['body'] = base64.b64decode(item['body'])
 
                         if args['no_body'] and 'body' in item:

--- a/kafka-monitor/kafkadump.py
+++ b/kafka-monitor/kafkadump.py
@@ -131,8 +131,11 @@ def main():
                     val = message.value
                     try:
                         item = json.loads(val)
+                        # Get the encoding. If it's not a key of item, return utf-8.
+                        encoding = item.get('encoding', 'utf-8')
+
                         if args['decode_base64'] and 'body' in item:
-                            item['body'] = base64.b64decode(item['body']).decode(item['encoding'])
+                            item['body'] = base64.b64decode(item['body']).decode(encoding)
 
                         if args['no_body'] and 'body' in item:
                             del item['body']

--- a/kafka-monitor/kafkadump.py
+++ b/kafka-monitor/kafkadump.py
@@ -10,6 +10,7 @@ import traceback
 import time
 import argparse
 import base64
+import six
 
 from scutils.settings_wrapper import SettingsWrapper
 from scutils.log_factory import LogFactory
@@ -56,6 +57,10 @@ def main():
                              required=False, const=True, default=False,
                              help="Do not include the raw html 'body' key in"
                              " the json dump of the topic")
+    dump_parser.add_argument('-jb', '--just-body', action='store_const',
+                             required=False, const=True, default=False,
+                             help="Just print the raw html 'body' key in"
+                                  " the json dump of the topic")
     dump_parser.add_argument('-p', '--pretty', action='store_const',
                              required=False, const=True, default=False,
                              help="Pretty print the json objects consumed")
@@ -126,10 +131,8 @@ def main():
                     val = message.value
                     try:
                         item = json.loads(val)
-                        if args['decode_base64'] and 'body' in item and 'encoding' in item:
+                        if args['decode_base64'] and 'body' in item:
                             item['body'] = base64.b64decode(item['body']).decode(item['encoding'])
-                        elif args['decode_base64'] and 'body' in item:
-                            item['body'] = base64.b64decode(item['body'])
 
                         if args['no_body'] and 'body' in item:
                             del item['body']
@@ -140,6 +143,11 @@ def main():
 
                     if args['pretty']:
                         print(json.dumps(item, indent=4))
+                    elif args['just_body']:
+                        if six.PY2:
+                            print(item['body'].encode('utf-8'))
+                        else:
+                            print(item['body'])
                     else:
                         print(item)
                     num_records = num_records + 1

--- a/rest/tests/test_rest_service.py
+++ b/rest/tests/test_rest_service.py
@@ -372,7 +372,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 500)
 
@@ -381,7 +381,7 @@ class TestRestService(TestCase):
             override.logger.error.reset_mock()
             results = override.test_error2()
             self.assertFalse(override.logger.error.called)
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, 'test data')
             self.assertEqual(results[1], 200)
 
@@ -390,7 +390,7 @@ class TestRestService(TestCase):
             override.logger.error.reset_mock()
             results = override.test_error3()
             self.assertFalse(override.logger.error.called)
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, 'test data')
             self.assertEqual(results[1], 109)
 
@@ -414,7 +414,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 400)
 
@@ -434,7 +434,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 400)
 
@@ -496,7 +496,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 400)
 
@@ -514,7 +514,7 @@ class TestRestService(TestCase):
                 "my_id": 'a908',
                 "node_health": 'RED'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
 
     def test_feed(self):
@@ -533,7 +533,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 500)
 
@@ -553,7 +553,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 500)
 
@@ -567,7 +567,7 @@ class TestRestService(TestCase):
                 u'error': None,
                 u'status': u'SUCCESS'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 200)
 
@@ -589,7 +589,7 @@ class TestRestService(TestCase):
                 u'error': None,
                 u'status': u'SUCCESS'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 200)
             self.assertFalse('key' in self.rest_service.uuids)
@@ -608,7 +608,7 @@ class TestRestService(TestCase):
                 u'error': None,
                 u'status': u'SUCCESS'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 200)
             self.assertTrue('key' in self.rest_service.uuids)
@@ -634,7 +634,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 500)
 
@@ -650,7 +650,7 @@ class TestRestService(TestCase):
                 u'error': None,
                 u'status': u'SUCCESS'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 200)
 
@@ -667,7 +667,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 404)
 
@@ -689,7 +689,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 500)
 
@@ -709,7 +709,7 @@ class TestRestService(TestCase):
                 },
                 u'status': u'FAILURE'
             }
-            data = json.loads(results[0].data)
+            data = json.loads(results[0].data.decode('utf-8'))
             self.assertEqual(data, d)
             self.assertEqual(results[1], 500)
 


### PR DESCRIPTION
**The crawling pipeline assumed that the item's body would always be encoded in _'utf-8'_.**

Unfortunately that is not the case with many websites.

A new field _"encoding"_ is added to the crawling item.

In case of _**base64**_ encoding being enabled in settings, use the website's encoding as it was detected by scrapy and saved in the new field.