### PR TITLE
Fix Travis build job

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -16,16 +16,16 @@
   tags: common
   when: ansible_os_family == "Debian"
 
-- name: Install EPEL repo.
-  yum:
-    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-    state: present
-  register: result
-  until: '"failed" not in result'
-  retries: 5
-  delay: 10
-  tags: common
-  when: ansible_os_family == "RedHat"
+# - name: Install EPEL repo.
+#   yum:
+#     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+#     state: present
+#   register: result
+#   until: '"failed" not in result'
+#   retries: 5
+#   delay: 10
+#   tags: common
+#   when: ansible_os_family == "RedHat"
 
 - name: Import EPEL GPG key.
   rpm_key:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ADVERTISED_HOST_NAME: kafka
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/elk/docker-compose.elk.yml
+++ b/elk/docker-compose.elk.yml
@@ -69,6 +69,7 @@ services:
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ADVERTISED_HOST_NAME: kafka
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/travis/docker-compose.test.yml
+++ b/travis/docker-compose.test.yml
@@ -51,6 +51,7 @@ services:
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ADVERTISED_HOST_NAME: kafka
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:


### PR DESCRIPTION
Both Centos 7 and Kafka docker containers have changed and needed updating, which ends up breaking the build job.

This PR tries corrects the build job so that it passes.