### PR TITLE
:pencil2: Typo on the document of kafka-monitor API section

### DIFF
--- a/docs/topics/kafka-monitor/api.rst
+++ b/docs/topics/kafka-monitor/api.rst
@@ -10,7 +10,7 @@ Kafka Topics
 
 **Outbound Result Kafka Topics:**
 
-- ``demo.crawled_firehouse`` - A firehose topic of all resulting crawls within the system. Any single page crawled by the Scrapy Cluster is guaranteed to come out this pipe.
+- ``demo.crawled_firehose`` - A firehose topic of all resulting crawls within the system. Any single page crawled by the Scrapy Cluster is guaranteed to come out this pipe.
 
 - ``demo.crawled_<appid>`` - A special topic created for unique applications that submit crawl requests. Any application can listen to their own specific crawl results by listening to the the topic created under the ``appid`` they used to submit the request. These topics are a subset of the crawl firehose data and only contain the results that are applicable to the application who submitted it.
 


### PR DESCRIPTION
This is a very simple PR for typo on the documents.
Here is the related issue: https://github.com/istresearch/scrapy-cluster/issues/183