### PR TITLE
Improve global page per domain filter documentation.

### DIFF
--- a/crawler/crawling/redis_global_page_per_domain_filter.py
+++ b/crawler/crawling/redis_global_page_per_domain_filter.py
@@ -7,9 +7,17 @@ from scrapy.utils.reqser import request_to_dict
 class RFGlobalPagePerDomainFilter(BaseDupeFilter):
     '''
     Redis-based request number filter
-    When this filter is enabled all crawl jobs sharing the same spider and crawlid
-    have GLOBAL_PAGE_PER_DOMAIN_LIMIT as a hard limit
-    of the max pages they are allowed to crawl.
+    When this filter is enabled, all crawl jobs have GLOBAL_PAGE_PER_DOMAIN_LIMIT as a hard limit
+    of the max pages they are allowed to crawl for each individual spiderid+domain+crawlid combination.
+    For example:
+        spiderid = "spid_1"
+        crawlid = "crawl_1"
+        domains = ['domain1.test', 'domain2.test']
+        GLOBAL_PAGE_PER_DOMAIN_LIMIT = 100
+    then the crawler will fetch at most 100 pages of domain1.test and 100 pages of domain2.test.
+
+    For each different spiderid or crawlid used, the domains will be crawled again for at most 100 pages each.
+
     Used when you don't want to pass domain_max_pages to all the individual CRAWL API requests.
     By default this filter is not enabled.
     '''

--- a/crawler/crawling/redis_global_page_per_domain_filter.py
+++ b/crawler/crawling/redis_global_page_per_domain_filter.py
@@ -7,10 +7,10 @@ from scrapy.utils.reqser import request_to_dict
 class RFGlobalPagePerDomainFilter(BaseDupeFilter):
     '''
     Redis-based request number filter
-    This filter is applied cluster wide.
-    When this filter is enabled all crawl jobs
+    When this filter is enabled all crawl jobs sharing the same spider and crawlid
     have GLOBAL_PAGE_PER_DOMAIN_LIMIT as a hard limit
     of the max pages they are allowed to crawl.
+    Used when you don't want to pass domain_max_pages to all the individual CRAWL API requests.
     By default this filter is not enabled.
     '''
 

--- a/docs/topics/crawler/settings.rst
+++ b/docs/topics/crawler/settings.rst
@@ -152,7 +152,7 @@ Number of seconds to keep **crawlid** specific duplication filters around after 
 
 Default: ``None``
 
-Hard upper limit of the number of pages allowed to be scraped per **spider, domain and crawlid** used together as a composite key. When not ``None`` it enables page limit filtering for jobs sharing the same **spider and crawlid** . When this limit is reached, the scraping for this composite key is stopped until the timeout specified with **GLOBAL_PAGE_PER_DOMAIN_LIMIT_TIMEOUT** is reached. It can only be overridden downwards (ie. scrape less than this limit) by the crawler's Kafka API argument domain_max_pages.
+Hard upper limit of the number of pages allowed to be scraped per **spider, domain and crawlid** used together as a composite key for all(!) crawling jobs. When not ``None``, all Crawl API requests grouped by the same **spiderid and crawlid** will impose this limit for each passed domain, individually. When this limit is reached, the scraping for this composite key is stopped until the timeout specified with **GLOBAL_PAGE_PER_DOMAIN_LIMIT_TIMEOUT** is reached. It can only be overridden downwards (ie. scrape less than this limit) by the crawler's Kafka API argument domain_max_pages. Used instead of the **domain_max_pages** Kafka Crawl API property when you want to set the same limit for all domains and all crawling jobs.
 
 **GLOBAL_PAGE_PER_DOMAIN_LIMIT_TIMEOUT**
 

--- a/docs/topics/crawler/settings.rst
+++ b/docs/topics/crawler/settings.rst
@@ -152,7 +152,7 @@ Number of seconds to keep **crawlid** specific duplication filters around after 
 
 Default: ``None``
 
-Hard upper limit of the number of pages allowed to be scraped per **spider, domain and crawlid** used together as a composite key. When not ``None`` it enables page limit filtering cluster wide. When this limit is reached, the scraping for this composite key is stopped until the timeout specified with **GLOBAL_PAGE_PER_DOMAIN_LIMIT_TIMEOUT** is reached. It can only be overridden downwards (ie. scrape less than this limit) by the crawler's Kafka API argument domain_max_pages.
+Hard upper limit of the number of pages allowed to be scraped per **spider, domain and crawlid** used together as a composite key. When not ``None`` it enables page limit filtering for jobs sharing the same **spider and crawlid** . When this limit is reached, the scraping for this composite key is stopped until the timeout specified with **GLOBAL_PAGE_PER_DOMAIN_LIMIT_TIMEOUT** is reached. It can only be overridden downwards (ie. scrape less than this limit) by the crawler's Kafka API argument domain_max_pages.
 
 **GLOBAL_PAGE_PER_DOMAIN_LIMIT_TIMEOUT**
 


### PR DESCRIPTION
This filter is not enabled "cluster wide". Instead it is shared among crawl requests having the same spider and crawlid.