### PR TITLE
Removed method timer wrapper in non-main thread

### DIFF
--- a/rest/tests/test_rest_service.py
+++ b/rest/tests/test_rest_service.py
@@ -14,6 +14,7 @@ import six
 
 from kafka.common import OffsetOutOfRangeError
 from kafka.conn import ConnectionStates
+from kafka.common import KafkaError
 from redis.exceptions import ConnectionError
 
 class Override(RestService):
@@ -337,7 +338,11 @@ class TestRestService(TestCase):
         # test bad
         self.rest_service._spawn_kafka_connection_thread = MagicMock()
         self.rest_service.logger.error = MagicMock()
-        self.rest_service.producer.send = MagicMock(side_effect=Exception)
+
+        bad_future = MagicMock()
+        bad_future.get = MagicMock(side_effect=KafkaError)
+
+        self.rest_service.producer.send = MagicMock(return_value=bad_future)
         self.assertFalse(self.rest_service._feed_to_kafka({}))
         self.assertTrue(self.rest_service.logger.error.called)
         self.assertTrue(self.rest_service._spawn_kafka_connection_thread.called)


### PR DESCRIPTION
Should allow us to catch errors more efficiently when we cannot connect to kafka for whatever reason. Was throwing the following log

```
rest_1 | {"message": "Uncaught Exception Thrown", "logger": "rest-service", "status": "FAILURE", "timestamp": "2018-09-24T15:16:49.882399Z", "data": null, "level": "ERROR", "error": {"message": "An error occurred while processing your request.", "cause": "", "exception": "signal only works in main thread", "ex": "Traceback (most recent call last):\n File \"rest_service.py\", line 59, in wrapper\n result = f(*args, **kw)\n File \"rest_service.py\", line 620, in feed\n result = self._feed_to_kafka(json_item)\n File \"rest_service.py\", line 573, in _feed_to_kafka\n return _feed(json_item)\n File \"/usr/local/lib/python2.7/site-packages/scutils/method_timer.py\", line 43, in f2\n old_handler = signal.signal(signal.SIGALRM, timeout_handler)\nValueError: signal only works in main thread\n"}}
```

To test:
1. Build the rest service container
```
$ docker-compose up -d --build rest
# this should bring up kafka, zookeeper, and redis
```
2. Send a message to kafka
```
$ curl localhost:5343/feed -H "Content-type:application/json" -d '{"appid":"testapp", "uuid":"blahblah1", "stats":"kafka-monitor"}'

# response
{"data":{"poll_id":"blahblah1"},"error":null,"status":"SUCCESS"}
```