### PR TITLE
Pass cookies through the distributed scheduler

### DIFF
--- a/crawler/crawling/distributed_scheduler.py
+++ b/crawler/crawling/distributed_scheduler.py
@@ -3,6 +3,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import str
 from past.builtins import basestring
+from six import string_types
 from builtins import object
 from scrapy.http import Request
 from scrapy.conf import settings
@@ -541,6 +542,11 @@ class DistributedScheduler(object):
             # extra check to add items to request
             if 'useragent' in req.meta and req.meta['useragent'] is not None:
                 req.headers['User-Agent'] = req.meta['useragent']
+            if 'cookie' in req.meta and req.meta['cookie'] is not None:
+                if isinstance(req.meta['cookie'], dict):
+                    req.cookies = req.meta['cookie']
+                elif isinstance(req.meta['cookie'], string_types):
+                    req.cookies = self.parse_cookie(req.meta['cookie'])
 
             return req
 
@@ -567,7 +573,7 @@ class DistributedScheduler(object):
         if 'cookie' in item and item['cookie'] is not None:
             if isinstance(item['cookie'], dict):
                 req.cookies = item['cookie']
-            elif isinstance(item['cookie'], basestring):
+            elif isinstance(item['cookie'], string_types):
                 req.cookies = self.parse_cookie(item['cookie'])
         return req
 


### PR DESCRIPTION
Allow cookies to be passed between requests of the same domain.
This was originally possible when using the master branch.