### PR TITLE
add timeout to urlopen. For some reason urlopen may block for a while.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docker-compose.override.yml
 
 # backup files
 *.bak
+*.swp

--- a/crawler/crawling/distributed_scheduler.py
+++ b/crawler/crawling/distributed_scheduler.py
@@ -280,8 +280,9 @@ class DistributedScheduler(object):
         self.old_ip = self.my_ip
         self.my_ip = '127.0.0.1'
         try:
+            timeout = settings.get('IP_ADDR_REQUEST_TIMEOUT', 5)
             obj = urllib.request.urlopen(settings.get('PUBLIC_IP_URL',
-                                  'http://ip.42.pl/raw'))
+                                  'http://ip.42.pl/raw'), timeout = timeout)
             results = self.ip_regex.findall(obj.read())
             if len(results) > 0:
                 self.my_ip = results[0]

--- a/crawler/crawling/settings.py
+++ b/crawler/crawling/settings.py
@@ -24,8 +24,8 @@ ZOOKEEPER_ID = 'all'
 ZOOKEEPER_HOSTS = 'localhost:2181'
 
 PUBLIC_IP_URL = 'http://ip.42.pl/raw'
-IP_ADDR_REGEX = '(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
-
+IP_ADDR_REGEX = r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
+IP_ADDR_REQUEST_TIMEOUT = 5
 # Don't cleanup redis queues, allows to pause/resume crawls.
 SCHEDULER_PERSIST = True
 


### PR DESCRIPTION
It is often blocked for quiet a while that requests are from China to 'http://ip.42.pl/raw'.
When `update_ipaddress` was blocked the spider hangs.