### PR TITLE
Fixed an error with MarkupSafe installation

### DIFF
--- a/rest/requirements.txt
+++ b/rest/requirements.txt
@@ -8,7 +8,7 @@ Jinja2==2.10  # Updated from 2.9.5
 jsonschema==2.6.0
 kafka-python==1.4.3  # Updated from 1.3.3
 kazoo==2.4.0  # Updated from 2.2.1
-MarkupSafe==1.0
+MarkupSafe==1.1.0 # Updated from 1.0
 mock==2.0.0
 nose==1.3.7
 pbr==4.0.3  # Updated from 2.0.0


### PR DESCRIPTION
MarkupSafe tries to import setuptools.Feature which results in an error as it's deprecated.
Details:
pallets/markupsafe#116
pypa/setuptools#2017