### PR TITLE
Fixed an error with MarkupSafe installation

### DIFF
--- a/rest/requirements.txt
+++ b/rest/requirements.txt
@@ -8,7 +8,7 @@ Jinja2==2.9.5 # Updated from 2.8
 jsonschema==2.6.0 # Updated from 2.5.1
 kafka-python==1.3.3 # Updated from 1.3.2
 kazoo==2.2.1
-MarkupSafe==1.0 # Updated from 0.23
+MarkupSafe==1.1.0 # Updated from 1.0
 mock==2.0.0
 nose==1.3.7
 pbr==2.0.0 # Updated from 1.10.0


### PR DESCRIPTION
MarkupSafe tries to import setuptools.Feature which results in an error as it's deprecated.
Details:
https://github.com/pallets/markupsafe/issues/116
https://github.com/pypa/setuptools/issues/2017