### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/topics/introduction/quickstart.rst
+++ b/docs/topics/introduction/quickstart.rst
@@ -3,7 +3,7 @@
 Quick Start
 ===========
 
-*This guide does not go into detail as to how everything works but, hopefully, it will get you scraping quickly. For more information about how each process works please see the rest of the documentation.*
+*This guide does not go into detail as to how everything works but it will hopefully get you scraping quickly. For more information about how each process works please see the rest of the documentation.*
 
 Setup
 -----

--- a/docs/topics/introduction/quickstart.rst
+++ b/docs/topics/introduction/quickstart.rst
@@ -3,12 +3,12 @@
 Quick Start
 ===========
 
-*This guide does not go into detail as to how everything works, but hopefully will get you scraping quickly. For more information about each process works please see the rest of the documentation.*
+*This guide does not go into detail as to how everything works but, hopefully, it will get you scraping quickly. For more information about how each process works please see the rest of the documentation.*
 
 Setup
 -----
 
-There are a number of different options available to set up Scrapy Cluster. You can chose to provision with the `Docker Quickstart`_, or manually configure via the `Cluster Quickstart`_ yourself.
+There are several options available to set up Scrapy Cluster. You can choose to provision with the `Docker Quickstart`_, or manually configure it via the `Cluster Quickstart`_ yourself.
 
 .. _docker_setup:
 
@@ -17,11 +17,11 @@ Docker Quickstart
 
 The Docker Quickstart will help you spin up a complete standalone cluster thanks to Docker and `Docker Compose <https://docs.docker.com/compose/>`_. All individual components will run in standard docker containers, and be controlled through the ``docker-compose`` command line interface.
 
-1) Ensure you have Docker Engine and Docker Compose installed on your machine. For more information about installation please refer to Docker's official documentation.
+1) Ensure you have Docker Engine and Docker Compose installed on your machine. For more installation information please refer to Docker's official documentation.
 
 2) Download and unzip the latest release `here <https://github.com/istresearch/scrapy-cluster/releases>`_.
 
-Lets assume our project is now in ``~/scrapy-cluster``
+Let's assume our project is now in ``~/scrapy-cluster``
 
 3) Run docker compose
 
@@ -31,7 +31,7 @@ Lets assume our project is now in ``~/scrapy-cluster``
 
 This will pull the latest stable images from Docker hub and build your scraping cluster.
 
-At time of writing, there is no Docker container to interface and run all of the tests within your compose-based cluster. Instead, if you wish to run the unit and integration tests plese see the following steps.
+At the time of writing, there is no Docker container to interface and run all of the tests within your compose-based cluster. Instead, if you wish to run the unit and integration tests please see the following steps.
 
 .. note:: If you want to switch to python3, just modify ``docker-compose.yml`` to change kafka_monitor, redis_monitor, crawler and rest image to python3's tag like kafka-monitor-dev-py3. You can find all available tag in `DockerHub Tags <https://hub.docker.com/r/istresearch/scrapy-cluster/tags/>`_
 
@@ -41,25 +41,25 @@ At time of writing, there is no Docker container to interface and run all of the
 
   ::
 
-    $ docker exec -it scrapycluster_kafka_monitor_1 bash
+    $ docker exec -it scrapy-cluster_kafka_monitor_1 bash
 
   Redis monitor
 
   ::
 
-    $ docker exec -it scrapycluster_redis_monitor_1 bash
+    $ docker exec -it scrapy-cluster_redis_monitor_1 bash
 
   Crawler
 
   ::
 
-    $ docker exec -it scrapycluster_crawler_1 bash
+    $ docker exec -it scrapy-cluster_crawler_1 bash
 
   Rest
 
   ::
 
-    $ docker exec -it scrapycluster_rest_1 bash
+    $ docker exec -it scrapy-cluster_rest_1 bash
 
 5) Run the unit and integration test for that component. Note that your output may be slightly different but your tests should pass consistently.
 
@@ -79,9 +79,9 @@ At time of writing, there is no Docker container to interface and run all of the
 
   OK
 
-This script will run both of offline unit tests and the online integration tests for your particular container. You will want to do this on all three component containers.
+This script will run both offline unit tests and online integration tests for your particular container. You will want to do this on all three component containers.
 
-You now appear to have a working docker environment, so jump down to `Your First Crawl`_ to finish the quickstart. Note that since this is a precanned cluster thanks to docker compose, you have everything already spun up except the dump utilities.
+You now appear to have a working docker environment, so jump down to `Your First Crawl`_ to finish the quickstart. Note that since this is a pre-canned cluster thanks to docker compose, you have everything already spun up except the dump utilities.
 
 .. _cluster_setup:
 
@@ -94,7 +94,7 @@ The Cluster Quickstart will help you set up your components across a number of d
 
 2) Download and unzip the latest release `here <https://github.com/istresearch/scrapy-cluster/releases>`_.
 
-Lets assume our project is now in ``~/scrapy-cluster``
+Let's assume our project is now in ``~/scrapy-cluster``
 
 3) Install the requirements on every machine
 
@@ -116,7 +116,7 @@ Lets assume our project is now in ``~/scrapy-cluster``
     Ran 9 tests in 0.045s
     ...
 
-Lets now setup and ensure our cluster can talk with Redis, Kafka, and Zookeeper
+Let's now setup and ensure our cluster can talk with Redis, Kafka, and Zookeeper
 
 5) Add a new file called ``localsettings.py`` in the Kafka Monitor folder.
 
@@ -134,9 +134,9 @@ Add the following to your new custom local settings.
     REDIS_PASSWORD = None
     KAFKA_HOSTS = 'scdev:9092'
 
-It is recommended you use this 'local' override instead of altering the default ``settings.py`` file, in order to preserve the original configuration the cluster comes with in case something goes wrong, or the original settings need updated.
+It is recommended you use this 'local' override instead of altering the default ``settings.py`` file, in order to preserve the original configuration the cluster comes with in case something goes wrong, or the original settings need to be updated.
 
-6) Now, lets run the online integration test to see if our Kafka Monitor is set up correctly
+6) Now, let's run the online integration test to see if our Kafka Monitor is set up correctly
 
 ::
 
@@ -149,7 +149,7 @@ It is recommended you use this 'local' override instead of altering the default 
 
     OK
 
-This integration test creates a dummy Kafka topic, writes a JSON message to it, ensures the Kafka Monitor reads the message, and puts the request into Redis.
+This integration test creates a dummy Kafka topic, writes a JSON message to it, ensures the Kafka Monitor reads the message and puts the request into Redis.
 
 .. warning:: If your integration test fails, please ensure the port(s) are open on the machine your Kafka cluster and your Redis host resides on, and that the particular machine this is set up on can access the specified hosts.
 
@@ -256,7 +256,7 @@ Add the following fields to override the defaults
 Your First Crawl
 ----------------
 
-At this point you should have a Scrapy Cluster setup that has been tested and appears to be operational. We can choose to start up either a bare bones cluster, or a fully operational cluster.
+At this point, you should have a Scrapy Cluster setup that has been tested and appears to be operational. We can choose to start up either a bare bones cluster, or a fully operational cluster.
 
 .. note:: You can append ``&`` to the end of the following commands to run them in the background, but we recommend you open different terminal windows to first get a feel of how the cluster operates.
 
@@ -321,13 +321,13 @@ The following commands outline what you would run in a traditional environment. 
 
        python kafkadump.py dump -t demo.outbound_firehose
 
-Which ever setup you chose, every process within should stay running for the remainder that your cluster is in an operational state.
+Whichever setup you chose, every process within should stay running for the remainder that your cluster is in an operational state.
 
 .. note:: If you chose to set the Rest service up, this section may also be performed via the :doc:`../rest/index` endpoint. You just need to ensure the JSON identified in the following section is properly fed into the :ref:`feed <feed_endpoint>` rest endpoint.
 
 *The following commands can be run from the command line, whether that is on the machine itself or inside the Kafka Monitor container depends on the setup chosen above.*
 
-1) We now need to feed the cluster a crawl request. This is done via the same Kafka Monitor python script, but with different command line arguements.
+1) We now need to feed the cluster a crawl request. This is done via the same Kafka Monitor python script, but with different command line arguments.
 
 ::
 
@@ -350,7 +350,7 @@ You will see an error message in the log if the script cannot connect to Kafka i
 2) After a successful request, the following chain of events should occur in order:
 
   #. The Kafka monitor will receive the crawl request and put it into Redis
-  #. The spider periodically checks for new requests, and will pull the request from the queue and process it like a normal Scrapy spider.
+  #. The spider periodically checks for new requests and will pull the request from the queue and process it like a normal Scrapy spider.
   #. After the scraped item is yielded to the Scrapy item pipeline, the Kafka Pipeline object will push the result back to Kafka
   #. The Kafka Dump utility will read from the resulting output topic, and print out the raw scrape object it received
 
@@ -382,7 +382,7 @@ The following things will occur for this action request:
 
 In this case we had 25 urls pending in the queue, so yours may be slightly different.
 
-4) If the crawl from step 1 is still running, lets stop it by issuing a ``stop`` action request (this requires a full deployment).
+4) If the crawl from step 1 is still running, let's stop it by issuing a ``stop`` action request (this requires a full deployment).
 
 Action Request:
 
@@ -402,8 +402,8 @@ The following things will occur for this action request:
 
         {u'total_purged': 90, u'server_time': 1450817758, u'crawlid': u'abc1234', u'spiderid': u'link', u'appid': u'testapp', u'action': u'stop'}
 
-In this case we had 90 urls removed from the queue. Those pending requests are now completely removed from the system and the spider will go back to being idle.
+In this case, we had 90 URLs removed from the queue. Those pending requests are now completely removed from the system and the spider will go back to being idle.
 
 --------------
 
-Hopefully you now have a working Scrapy Cluster that allows you to submit jobs to the queue, receive information about your crawl, and stop a crawl if it gets out of control. For a more in depth look, please continue reading the documentation for each component.
+Hopefully, you now have a working Scrapy Cluster that allows you to submit jobs to the queue, receive information about your crawl, and stop a crawl if it gets out of control. For a more in-depth look, please continue reading the documentation for each component.

--- a/docs/topics/introduction/quickstart.rst
+++ b/docs/topics/introduction/quickstart.rst
@@ -79,7 +79,7 @@ At the time of writing, there is no Docker container to interface and run all of
 
   OK
 
-This script will run both offline unit tests and online integration tests for your particular container. You will want to do this on all three component containers.
+This script will run both offline unit tests and online integration tests for your particular container. You will want to do this on all the component containers.
 
 You now appear to have a working docker environment, so jump down to `Your First Crawl`_ to finish the quickstart. Note that since this is a pre-canned cluster thanks to docker compose, you have everything already spun up except the dump utilities.
 


### PR DESCRIPTION
Some spelling/grammar fix and correct docker container names in the `docker ti `examples.
