### PR TITLE
Crawler image - Python dependency fix

### DIFF
--- a/docker/crawler/Dockerfile.py3
+++ b/docker/crawler/Dockerfile.py3
@@ -3,7 +3,7 @@ MAINTAINER Madison Bahmer <madison.bahmer@istresearch.com>
 
 # os setup
 RUN apt-get update && apt-get -y install \
-  python-lxml \
+  python3-lxml \
   build-essential \
   libssl-dev \
   libffi-dev \


### PR DESCRIPTION
I tried to use "docker-compose up" and the crawler image failed to build.

I looked at the dependency that was failing to download and found that the name of the lib was missing a letter.

After the change everything worked well.